### PR TITLE
convenient checbox in "edit competitor" dialog for adding SI card to lent table

### DIFF
--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -190,8 +190,7 @@ CompetitorWidget::CompetitorWidget(QWidget *parent) :
 	{
 		// update checbox if si card in lent table
 		Qt::CheckState ch_state;
-		bool a = isCardInLentTable(new_si_number);
-		if (a) {
+		if (isCardInLentTable(new_si_number)) {
 			ch_state = Qt::Checked;
 		}
 		else {

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -379,10 +379,9 @@ bool CompetitorWidget::saveData()
 		if(Super::saveData())
 		{
 			ret = saveRunsTable();
-			updateLentcardsTable();
+			updateLentcardsTable(); // update cardlent table if lent status changed
 		}
 		transaction.commit();
-		 // update cardlent table if lent status changed
 	}
 	catch (BadDataInputException &e) {
 		qf::qmlwidgets::dialogs::MessageBox::showError(this, e.message());

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.h
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.h
@@ -33,6 +33,8 @@ private:
 	QVector<int> juniorAges();
 	QVector<int> veteranAges();
 	QString classNameFromRegistration(const QString &registration);
+	bool isCardInLentTable(int);
+	void updateLentcardsTable();
 
 	void showRunsTable(int stage_id);
 private:

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.ui
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.ui
@@ -261,6 +261,9 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;Based on the checbox state, the SI card lent status will be updated in the table of lent cards after dialog is saved.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
            <property name="text">
             <string>lent card</string>
            </property>

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.ui
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.ui
@@ -58,8 +58,49 @@
       <string>Competitor</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
+      <item row="2" column="5">
+       <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_3">
+        <property name="dataId" stdset="0">
+         <string notr="true">competitors.lastName</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>&amp;Registration</string>
+        </property>
+        <property name="buddy">
+         <cstring>lineEdit_4</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_6">
+        <property name="dataId" stdset="0">
+         <string notr="true">competitors.club</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_4">
+        <property name="dataId" stdset="0">
+         <string notr="true">competitors.registration</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="3">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Co&amp;untry</string>
+        </property>
+        <property name="buddy">
+         <cstring>lineEdit_7</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="label_cbxClass">
         <property name="text">
          <string>&amp;Class</string>
         </property>
@@ -68,10 +109,54 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="3">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>&amp;Last name</string>
+        </property>
+        <property name="buddy">
+         <cstring>lineEdit_3</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="5">
+       <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_5">
+        <property name="dataId" stdset="0">
+         <string notr="true">competitors.licence</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Licenc&amp;e</string>
+        </property>
+        <property name="buddy">
+         <cstring>lineEdit_5</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="2">
        <widget class="qf::qmlwidgets::ForeignKeyComboBox" name="cbxClass">
         <property name="dataId" stdset="0">
          <string notr="true">competitors.classId</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>&amp;Note</string>
+        </property>
+        <property name="buddy">
+         <cstring>lineEdit_8</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2" colspan="4">
+       <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_8">
+        <property name="dataId" stdset="0">
+         <string notr="true">competitors.note</string>
         </property>
        </widget>
       </item>
@@ -85,13 +170,13 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="4">
-       <widget class="quickevent::gui::si::SiIdEdit" name="edSiId">
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      <item row="5" column="1">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Clu&amp;b</string>
         </property>
-        <property name="dataId" stdset="0">
-         <string notr="true">competitors.siId</string>
+        <property name="buddy">
+         <cstring>lineEdit_6</cstring>
         </property>
        </widget>
       </item>
@@ -112,106 +197,79 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="3">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>&amp;Last name</string>
-        </property>
-        <property name="buddy">
-         <cstring>lineEdit_3</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="4">
-       <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_3">
-        <property name="dataId" stdset="0">
-         <string notr="true">competitors.lastName</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>&amp;Registration</string>
-        </property>
-        <property name="buddy">
-         <cstring>lineEdit_4</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="3">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Licenc&amp;e</string>
-        </property>
-        <property name="buddy">
-         <cstring>lineEdit_5</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="4">
-       <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_5">
-        <property name="dataId" stdset="0">
-         <string notr="true">competitors.licence</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Clu&amp;b</string>
-        </property>
-        <property name="buddy">
-         <cstring>lineEdit_6</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_6">
-        <property name="dataId" stdset="0">
-         <string notr="true">competitors.club</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="3">
-       <widget class="QLabel" name="label_8">
-        <property name="text">
-         <string>Co&amp;untry</string>
-        </property>
-        <property name="buddy">
-         <cstring>lineEdit_7</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="4">
+      <item row="5" column="5">
        <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_7">
         <property name="dataId" stdset="0">
          <string notr="true">competitors.country</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>&amp;Note</string>
+      <item row="1" column="5">
+       <widget class="QFrame" name="siBox">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
         </property>
-        <property name="buddy">
-         <cstring>lineEdit_8</cstring>
+        <property name="lineWidth">
+         <number>0</number>
         </property>
-       </widget>
-      </item>
-      <item row="5" column="2" colspan="3">
-       <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_8">
-        <property name="dataId" stdset="0">
-         <string notr="true">competitors.note</string>
+        <property name="midLineWidth">
+         <number>0</number>
         </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="qf::qmlwidgets::LineEdit" name="lineEdit_4">
-        <property name="dataId" stdset="0">
-         <string notr="true">competitors.registration</string>
-        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <property name="spacing">
+          <number>8</number>
+         </property>
+         <property name="sizeConstraint">
+          <enum>QLayout::SetNoConstraint</enum>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="quickevent::gui::si::SiIdEdit" name="edSiId">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
+           </property>
+           <property name="singleStep">
+            <number>0</number>
+           </property>
+           <property name="dataId" stdset="0">
+            <string notr="true">competitors.siId</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="chkLentCard">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>lent card</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
@@ -288,7 +346,6 @@
  </customwidgets>
  <tabstops>
   <tabstop>cbxClass</tabstop>
-  <tabstop>edSiId</tabstop>
   <tabstop>lineEdit_2</tabstop>
   <tabstop>lineEdit_3</tabstop>
   <tabstop>lineEdit_4</tabstop>


### PR DESCRIPTION
![Screenshot from 2020-03-17 17-51-15](https://user-images.githubusercontent.com/24588500/76880667-4f0f7a00-6878-11ea-88c4-91e0e70faafa.png)

Přidává k `edit competitor` dialogu checbox zda je (či má být přidán) čip v tabulce půjčovaných čipů.
Při změně čisla čipu se stav checboxu dle databáze aktualizuje.
Pokud došlo vůči databázi ke změně je po uložení dialogu tato změna zabsána do databáze.

Připomínky vítány.