### PR TITLE
improve class suggestion

### DIFF
--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -273,9 +273,6 @@ bool CompetitorWidget::load(const QVariant &id, int mode)
 	return false;
 }
 
-bool greater_equal(int a, int b) {return a >= b;}
-bool less_equal(int a, int b) {return a <= b;}
-
 QString CompetitorWidget::guessClassFromRegistration(const QString &registration)
 {
 	// get list of classes without preceding letter - eg. 12,14,18,21,35,..

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -350,7 +350,8 @@ void CompetitorWidget::onRegistrationSelected(const QVariantMap &values)
 		qfDebug() << "\t" << s << "->" << values.value(s);
 		doc->setValue(s, values.value(s));
 	}
-	if(!doc->isDirty(QStringLiteral("classId"))) {
+	// if no class is set, guess class from registration
+	if(ui->cbxClass->currentText().isEmpty()) {
 		QString class_name_prefix = guessClassFromRegistration(values.value("registration").toString());
 		if(!class_name_prefix.isEmpty()) {
 			for (int i = 0; i < ui->cbxClass->count(); ++i) {

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -353,7 +353,7 @@ void CompetitorWidget::onRegistrationSelected(const QVariantMap &values)
 		qfDebug() << "\t" << s << "->" << values.value(s);
 		doc->setValue(s, values.value(s));
 	}
-	if(true) {
+	if(!doc->isDirty(QStringLiteral("classId"))) {
 		QString class_name_prefix = guessClassFromRegistration(values.value("registration").toString());
 		if(!class_name_prefix.isEmpty()) {
 			for (int i = 0; i < ui->cbxClass->count(); ++i) {

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.cpp
@@ -297,7 +297,7 @@ QString CompetitorWidget::guessClassFromRegistration(const QString &registration
 	char gender = (registration.mid(5, 1).toInt() == 5)? 'D': 'H';
 	bool (*comp)(int, int) = &grearet_equal;
 
-	if (runner_age >= 21)
+	if (runner_age < 21)
 	{
 		comp = &less_equal;
 		std::reverse(classes.begin(), classes.end());

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.h
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.h
@@ -30,9 +30,9 @@ private:
 	//void onRunsTableCustomContextMenuRequest(const QPoint &pos);
 	bool saveData() Q_DECL_OVERRIDE;
 
-	QVector<int> juniorAges();
-	QVector<int> veteranAges();
-	QString classNameFromRegistration(const QString &registration);
+	QString juniorAges(char gender, int age);
+	QString veteranAges(char gender, int age);
+	QString guessClassFromRegistration(const QString &registration);
 
 	void showRunsTable(int stage_id);
 private:

--- a/quickevent/app/plugins/Competitors/src/competitorwidget.h
+++ b/quickevent/app/plugins/Competitors/src/competitorwidget.h
@@ -30,8 +30,6 @@ private:
 	//void onRunsTableCustomContextMenuRequest(const QPoint &pos);
 	bool saveData() Q_DECL_OVERRIDE;
 
-	QString juniorAges(char gender, int age);
-	QString veteranAges(char gender, int age);
 	QString guessClassFromRegistration(const QString &registration);
 
 	void showRunsTable(int stage_id);


### PR DESCRIPTION
Přepisoval jsem aby častěji fungovalo automatické vybírání kategorie. např. věk 17 se dokáže přeřadit i k H18, pokud není tak H21.. či pro veterány naopak 48 k H45.

Často (možná nikdy) však k samotnému pokusu o vybrání ani nedojde, neprojde se přes podmínku `!doc->isDirty(QStringLiteral("classId")`. Pořádně nevím, co kontroluje, ale asi nefunguje dle očekávání. Pomoc vítána.


```c++
void CompetitorWidget::onRegistrationSelected(const QVariantMap &values)
{
	qfLogFuncFrame();
	auto *doc = dataController()->document();
	for(auto s : {"firstname", "lastname", "registration", "licence", "siid"}) {
		qfDebug() << "\t" << s << "->" << values.value(s);
		doc->setValue(s, values.value(s));
	}
	if(!doc->isDirty(QStringLiteral("classId"))) {
		QString class_name_prefix = guessClassFromRegistration(values.value("registration").toString());
		if(!class_name_prefix.isEmpty()) {
			for (int i = 0; i < ui->cbxClass->count(); ++i) {
				QString class_name = ui->cbxClass->itemText(i);
				if(class_name.startsWith(class_name_prefix)) {
					ui->cbxClass->setCurrentText(class_name);
					break;
				}
			}
		}
	}
}
```