### PR TITLE
warn user that connection to database is needed when exiting connection dialog

### DIFF
--- a/quickevent/app/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/plugins/Event/src/eventplugin.cpp
@@ -636,6 +636,11 @@ void EventPlugin::connectToSqlServer()
 								     "Program features will be limited.\n\n"
 								     "To connect to a database or to choose a working directory where event files can be stored, navigate to:\n "
 								     "\"File -> Connect to database\" "));
+				m_actCreateEvent->setEnabled(false);
+				m_actOpenEvent->setEnabled(false);
+				m_actEditEvent->setEnabled(false);
+				m_actExportEvent_qbe->setEnabled(false);
+				m_actImportEvent_qbe->setEnabled(false);
 			}
 			return;
 		}

--- a/quickevent/app/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/plugins/Event/src/eventplugin.cpp
@@ -630,9 +630,15 @@ void EventPlugin::connectToSqlServer()
 	dlg.setCentralWidget(conn_w);
 	while(!connect_ok) {
 		conn_w->loadSettings();
-		if(!dlg.exec())
+		if(!dlg.exec()) {
+			if(!m_sqlServerConnected) {
+				qfd::MessageBox::showWarning(fwk, tr("You are not connected to database.\n"
+								     "Program features will be limited.\n\n"
+								     "To connect to a database or to choose a working directory where event files can be stored, navigate to:\n "
+								     "\"File -> Connect to database\" "));
+			}
 			return;
-
+		}
 		conn_w->saveSettings();
 		connection_type = conn_w->connectionType();
 		qfDebug() << "connection_type:" << (int)connection_type;

--- a/quickevent/app/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/plugins/Event/src/eventplugin.cpp
@@ -636,13 +636,8 @@ void EventPlugin::connectToSqlServer()
 								     "Program features will be limited.\n\n"
 								     "To connect to a database or to choose a working directory where event files can be stored, navigate to:\n "
 								     "\"File -> Connect to database\" "));
-				m_actCreateEvent->setEnabled(false);
-				m_actOpenEvent->setEnabled(false);
-				m_actEditEvent->setEnabled(false);
-				m_actExportEvent_qbe->setEnabled(false);
-				m_actImportEvent_qbe->setEnabled(false);
 			}
-			return;
+			break;
 		}
 		conn_w->saveSettings();
 		connection_type = conn_w->connectionType();
@@ -706,6 +701,7 @@ void EventPlugin::connectToSqlServer()
 	m_actEditEvent->setEnabled(connect_ok);
 	m_actExportEvent_qbe->setEnabled(connect_ok);
 	m_actImportEvent_qbe->setEnabled(connect_ok);
+	m_actEditStage->setEnabled(connect_ok);
 	if(connect_ok) {
 		openEvent(conn_w->eventName());
 	}


### PR DESCRIPTION
I wanted to be strict and prevent user entering the application if database is not connected. However, when a modal is opened it is not possible to exit or close the application (https://bugreports.qt.io/browse/QTBUG-29915), so it was not possible to exit the application without first connection to database/choosing the working directory. In order not to restrict the user from exiting the application I scraped the idea of prohibiting access, but at least introduced a convenient warning, that connection to database is needed and left a hint where to find this setting later.

edit: + disable menu when database is not connected