### PR TITLE
refactor event open

### DIFF
--- a/quickevent/app/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/plugins/Event/src/eventplugin.cpp
@@ -889,14 +889,20 @@ bool EventPlugin::openEvent(const QString &_event_name)
 			ok = false;
 	}
 	if(db_event_names.isEmpty()) {
+		// openEvent function was called on empty database
 		qfd::MessageBox::showInfo(fwk, empty_message);
 		ok = false;
 	}
 	else if (!db_event_names.contains(event_name)) {
+		// database does not contain given event_name => ask which event to open
 		event_name = QInputDialog::getItem(fwk, tr("Open event"), tr("select event to open:"), db_event_names, 0, false, &ok);
 	}
-	if(!eventName().isEmpty() && db_event_names.contains(eventName()) && !ok)
+	// if given event_name is in the db, preceeding conditions were skipped => ok => open event_name
+	// if dialog was succesfull => ok => open event_name
+	// if dialog was canceled => !ok => close event and disable menu options
+	if(!eventName().isEmpty() && db_event_names.contains(eventName()) && !ok) // open event dialog was canceled and event is already opened => no change, return
 		return true;
+
 	closeEvent();
 
 	if(ok) {

--- a/quickevent/app/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/plugins/Event/src/eventplugin.cpp
@@ -884,9 +884,6 @@ bool EventPlugin::openEvent(const QString &_event_name)
 			db_event_names = existingFileEventNames(connection_settings.singleWorkingDir());
 			empty_message = tr("Working directory does not contain any event files.\nStart by creating or importing an event.");
 			break;
-		default:
-			qfError() << "Invalid connection type:" << static_cast<int>(connection_type);
-			ok = false;
 	}
 	if(db_event_names.isEmpty()) {
 		// openEvent function was called on empty database

--- a/quickevent/app/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/plugins/Event/src/eventplugin.cpp
@@ -895,7 +895,7 @@ bool EventPlugin::openEvent(const QString &_event_name)
 	else if (!db_event_names.contains(event_name)) {
 		event_name = QInputDialog::getItem(fwk, tr("Open event"), tr("select event to open:"), db_event_names, 0, false, &ok);
 	}
-	if(!event_name.isEmpty() && db_event_names.contains(event_name) && !ok)
+	if(!eventName().isEmpty() && db_event_names.contains(eventName()) && !ok)
 		return true;
 	closeEvent();
 


### PR DESCRIPTION
fixed for various cases:

- given event name is in db => open straight (same as now)
- db is empty => do not display open dialog, guide user to create or open event
- db has events => show open dialog (same as now)
- open dialog canceled => current event stays opened #487

and  disable edit and export menu items when no event is currently selected