### PR TITLE
allow clearing spinbox when editing SI card number

### DIFF
--- a/libquickevent/libquickeventgui/src/si/siidedit.cpp
+++ b/libquickevent/libquickeventgui/src/si/siidedit.cpp
@@ -11,4 +11,11 @@ SiIdEdit::SiIdEdit(QWidget *parent)
 	setMinimum(0);
 }
 
+void SiIdEdit::fixup(QString &input) const
+{
+    if (input.isEmpty())
+	input = QString::fromLatin1("0");
+    Super::fixup(input);
+}
+
 }}}

--- a/libquickevent/libquickeventgui/src/si/siidedit.h
+++ b/libquickevent/libquickeventgui/src/si/siidedit.h
@@ -18,6 +18,8 @@ class QUICKEVENTGUI_DECL_EXPORT SiIdEdit : public qf::qmlwidgets::SpinBox
 	Q_PROPERTY(quickevent::core::si::SiId siid READ siid WRITE setSiid USER true)
 private:
 	typedef qf::qmlwidgets::SpinBox Super;
+protected:
+	void fixup(QString &input) const override;
 public:
 	SiIdEdit(QWidget *parent = nullptr);
 


### PR DESCRIPTION
Currently, when SI card number edit box is cleared and you leave the edit box, the SI card number appears again. It is not possible to just clear the editing field unless the card number is set explicitly to 0.

this commit makes it so when SI card number is cleared, it is set to 0 instead.

code inspiration: https://codereview.qt-project.org/c/qt/qtbase/+/121767