### PR TITLE
include SSL and Postgre libraries in linux build

### DIFF
--- a/quickevent/make-dist.sh
+++ b/quickevent/make-dist.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #APP_VER=0.0.1
 APP_NAME=quickevent
 SRC_DIR=/home/fanda/proj/quickbox
@@ -19,6 +18,7 @@ help() {
 	echo "    --work-dir <path>        directory where build files and AppImage will be created, ie: /home/me/quickevent/AppImage"
 	echo "    --appimage-tool <path>      path to AppImageTool, ie: /home/me/appimagetool-x86_64.AppImage"
 	echo "    --no-clean               do not rebuild whole project when set to 1"
+	echo "    --lib-dir               path where to find libpq.so, libcrypto.so, libssl.so, ie: /usr/lib64/ or /usr/lib/x86_64-linux-gnu/"
 	echo -e "\n"
 	echo "example: make-dist.sh --src-dir /home/me/quickbox --qt-dir /home/me/qt5/5.13.1/gcc_64 --work-dir /home/me/quickevent/AppImage --image-tool /home/me/appimagetool-x86_64.AppImage"
 	exit 0
@@ -63,6 +63,11 @@ case $key in
 	shift # past argument
 	shift # past value
 	;;
+	--lib-dir)
+	LIB_DIR="$2"
+	shift # past argument
+	shift # past value
+	;;
 	--no-clean)
 	NO_CLEAN=1
 	shift # past value
@@ -99,6 +104,10 @@ if [ ! -f $APP_IMAGE_TOOL ]; then
 fi
 if [ ! -x $APP_IMAGE_TOOL ]; then
 	error "AppImageTool file must be executable, use chmod +x $APP_IMAGE_TOOL\n"
+	help
+fi
+if [ -z $LIB_DIR ] && [ ! -f "${LIB_DIR}libcrypto.so" ] || [ ! -f "${LIB_DIR}libssl.so" ] || [ ! -f "${LIB_DIR}libpq.so"]; then
+	error "folder $LIB_DIR does not contain required libraries"
 	help
 fi
 
@@ -194,6 +203,12 @@ $RSYNC $QT_DIR/plugins/audio/ $DIST_BIN_DIR/audio/
 
 mkdir -p $DIST_QML_DIR
 $RSYNC $QT_DIR/qml/QtQml $DIST_BIN_DIR/
+
+if [ ! -z $LIB_DIR ]; then
+	$RSYNC $LIB_DIR/libcrypto.so* $DIST_LIB_DIR
+	$RSYNC $LIB_DIR/libssl.so* $DIST_LIB_DIR
+	$RSYNC $LIB_DIR/libpq.so* $DIST_LIB_DIR
+fi
 
 ARTIFACTS_DIR=$WORK_DIR/artifacts
 mkdir -p $ARTIFACTS_DIR


### PR DESCRIPTION
add an option to include libcripto.so, libssl.so, libpq.so for the linux
build
~~Tested on fresh CentOS install that connection to oris is working with
this commit included, which did not work before.
Included also a library for connecting to postgresql databse, this is not
tested.~~
edit:
Tested. Connections to ORIS and PostgreSQL database work on fresh system.