### PR TITLE
Updated deprecated command in GitHub actions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -28,7 +28,7 @@ jobs:
         
     - name: Get app version
       run: | 
-        echo "::set-env name=VERSION::`grep APP_VERSION quickevent/app/quickevent/src/appversion.h | cut -d\\" -f2`"
+        echo "VERSION=`grep APP_VERSION quickevent/app/quickevent/src/appversion.h | cut -d\\" -f2`" >> $GITHUB_ENV
           
     - name: Get AppImageTool
       run: |
@@ -117,7 +117,7 @@ jobs:
         done
       
     - name: Get app version
-      run: echo "::set-env name=VERSION::`grep APP_VERSION quickevent/app/quickevent/src/appversion.h | cut -d\\" -f2`"
+      run: echo "VERSION=`grep APP_VERSION quickevent/app/quickevent/src/appversion.h | cut -d\\" -f2`" >> $GITHUB_ENV
   
     - name: Create installer
       run: |


### PR DESCRIPTION
set-env command replaced by `$GITHUB_ENV`

> The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Warning found: https://github.com/Quick-Event/quickbox/actions/runs/291335975