### PR TITLE
Oprava tisku lístečku po přiřazení - fix #331

### DIFF
--- a/quickevent/app/plugins/Receipts/src/receiptsplugin.cpp
+++ b/quickevent/app/plugins/Receipts/src/receiptsplugin.cpp
@@ -494,7 +494,7 @@ bool ReceiptsPlugin::isAutoPrintEnabled()
 void ReceiptsPlugin::printOnAutoPrintEnabled(int card_id)
 {
 	if(isAutoPrintEnabled())
-		printCard(card_id);
+		printReceipt(card_id);
 }
 
 


### PR DESCRIPTION
Po přiřazení neznámého čipu se zapnutým autoprintem je nyní volána špatná metoda pro tisk lístečků – vytisknou se data čipu, ne mezičasy.