### PR TITLE
Opraven build pro windows

### DIFF
--- a/datafiles.pri
+++ b/datafiles.pri
@@ -20,7 +20,5 @@ win32 {
 	POST_TARGETDEPS += datafiles
 	QMAKE_EXTRA_TARGETS += datafiles
 	datafiles.commands = \
-		robocopy $$shell_path($$SRC_DATA_DIR) $$shell_path($$DEST_DATA_DIR) /IS /E
-		# robocopy 0-7 exit codes are not an error
-		IF %ERRORLEVEL% LSS 8 SET ERRORLEVEL=0
+		xcopy $$system_quote($$system_path($$SRC_DATA_DIR)) $$system_quote($$system_path($$DEST_DATA_DIR)) /s /e /y /i
 }


### PR DESCRIPTION
V současné době se při buildu nezavolá robocopy (minimálně se nevolá u mě a ani na github actions podle logu). V instačním souboru potom nejsou qml soubory, ikony, ...