### PR TITLE
fix deprecated implicit copy assignment operator

### DIFF
--- a/libqf/libqfcore/src/core/string.h
+++ b/libqf/libqfcore/src/core/string.h
@@ -17,6 +17,11 @@ public:
 	String() : QString() {}
 	String(const QString &str) : QString(str) {}
 	String(const String &str) : QString(str) {}
+	qf::core::String& operator=(const String &str) {
+		clear();
+		append(str);
+		return *this;
+	}
 public:
 	static const bool TrimParts = true;
 public:

--- a/libqf/libqfcore/src/core/string.h
+++ b/libqf/libqfcore/src/core/string.h
@@ -16,12 +16,6 @@ class QFCORE_DECL_EXPORT String : public QString
 public:
 	String() : QString() {}
 	String(const QString &str) : QString(str) {}
-	String(const String &str) : QString(str) {}
-	qf::core::String& operator=(const String &str) {
-		clear();
-		append(str);
-		return *this;
-	}
 public:
 	static const bool TrimParts = true;
 public:


### PR DESCRIPTION
```
warning: implicitly-declared ‘qf::core::String& qf::core::String::operator=(const qf::core::String&)’ is deprecated [-Wdeprecated-copy]
```