### PR TITLE
fix obsolete Qt::ItemDataRole values

### DIFF
--- a/libqf/libqfcore/src/model/sqltablemodel.cpp
+++ b/libqf/libqfcore/src/model/sqltablemodel.cpp
@@ -51,7 +51,7 @@ QVariant SqlTableModel::data(const QModelIndex &index, int role) const
 			}
 		}
 	}
-	else if(role == Qt::BackgroundColorRole) {
+	else if(role == Qt::BackgroundRole) {
 		ColumnDefinition cd = columnDefinition(index.column());
 		int cast_type = cd.castType();
 		if(cast_type == qMetaTypeId<qf::core::sql::DbEnum>()) {
@@ -71,7 +71,7 @@ QVariant SqlTableModel::data(const QModelIndex &index, int role) const
 			return QVariant();
 		}
 	}
-	else if(role == Qt::TextColorRole) {
+	else if(role == Qt::ForegroundRole) {
 		ColumnDefinition cd = columnDefinition(index.column());
 		int cast_type = cd.castType();
 		if(cast_type == qMetaTypeId<qf::core::sql::DbEnum>()) {

--- a/libqf/libqfcore/src/model/tablemodel.cpp
+++ b/libqf/libqfcore/src/model/tablemodel.cpp
@@ -197,7 +197,7 @@ QVariant TableModel::data(const QModelIndex &index, int role) const
 			}
 		}
 	}
-	else if(role == Qt::TextColorRole) {
+	else if(role == Qt::ForegroundRole) {
 		int type = columnType(index.column());
 		if(type == QVariant::ByteArray)
 			return QColor(Qt::blue);
@@ -206,7 +206,7 @@ QVariant TableModel::data(const QModelIndex &index, int role) const
 		}
 		ret = QVariant();
 	}
-	else if (role == Qt::BackgroundColorRole) {
+	else if (role == Qt::BackgroundRole) {
 		/// delegate does it
 	}
 	else if (role == Qt::CheckStateRole) {


### PR DESCRIPTION
fix warnings reported in IDE
`Qt::BackgroundColorRole` and `Qt::TextColorRole` are obsolete
https://doc.qt.io/qt-5/qt.html#ItemDataRole-enum