### PR TITLE
fix TimeToClose shows zero, resolve #578

### DIFF
--- a/quickevent/app/plugins/Runs/src/eventstatisticswidget.cpp
+++ b/quickevent/app/plugins/Runs/src/eventstatisticswidget.cpp
@@ -134,7 +134,7 @@ EventStatisticsModel::EventStatisticsModel(QObject *parent)
 				.orderBy("runs.timeMs")
 				.limit(3)
 				.as("results3");
-			qb_third_time.select("MAX(timeMs)")//.select("COUNT(timeMs) AS count3")
+			qb_third_time.select("CASE WHEN COUNT(timeMs) == 3 THEN MAX(timeMs) ELSE NULL END")
 					.from(qb.toString());
 		}
 
@@ -176,11 +176,11 @@ QVariant EventStatisticsModel::value(int row_ix, int column_ix) const
 		if(runners_count == runners_finished) {
 			return 0;
 		}
-		if(runners_finished < 3) {
+		int time3_msec = value(row_ix, col_time3Ms).toInt();
+		if(time3_msec == 0) {
 			return QVariant();
 		}
 		int start_last_msec = value(row_ix, col_startLastMs).toInt();
-		int time3_msec = value(row_ix, col_time3Ms).toInt();
 		int time_to_close_msec = stage_start_msec + start_last_msec + time3_msec - curr_time_msec;
 		if(time_to_close_msec < 0)
 			time_to_close_msec = 0;

--- a/quickevent/app/plugins/Runs/src/eventstatisticswidget.cpp
+++ b/quickevent/app/plugins/Runs/src/eventstatisticswidget.cpp
@@ -200,8 +200,8 @@ QVariant EventStatisticsModel::value(int row_ix, int column_ix) const
 		QDateTime dt2 = QDateTime::currentDateTime();
 		if(!dt1.isValid())
 			return QVariant{QVariant::Int};
-		int cnt = dt1.msecsTo(dt2);
-		return cnt;
+		int time_since_last_printed_msec = dt1.msecsTo(dt2);
+		return time_since_last_printed_msec;
 	}
 	return Super::value(row_ix, column_ix);
 }

--- a/quickevent/app/plugins/Runs/src/eventstatisticswidget.cpp
+++ b/quickevent/app/plugins/Runs/src/eventstatisticswidget.cpp
@@ -171,30 +171,31 @@ QVariant EventStatisticsModel::value(int row_ix, int column_ix) const
 	if(column_ix == col_timeToCloseMs) {
 		int stage_start_msec = eventPlugin()->stageStartMsec(eventPlugin()->currentStageId());
 		int curr_time_msec = QTime::currentTime().msecsSinceStartOfDay();
-		//int runners_count = value(row_ix, col_runnersCount).toInt();
+		int runners_count = value(row_ix, col_runnersCount).toInt();
 		int runners_finished = value(row_ix, col_runnersFinished).toInt();
-		if(runners_finished == 0) {
+		if(runners_count == runners_finished) {
+			return 0;
+		}
+		if(runners_finished < 3) {
 			return QVariant();
 		}
-		else {
-			int start_last_msec = value(row_ix, col_startLastMs).toInt();
-			int time3_msec = value(row_ix, col_time3Ms).toInt();
-			int time_to_close_msec = stage_start_msec + start_last_msec + time3_msec - curr_time_msec;
-			if(time_to_close_msec < 0)
-				time_to_close_msec = 0;
-			return time_to_close_msec;
-		}
+		int start_last_msec = value(row_ix, col_startLastMs).toInt();
+		int time3_msec = value(row_ix, col_time3Ms).toInt();
+		int time_to_close_msec = stage_start_msec + start_last_msec + time3_msec - curr_time_msec;
+		if(time_to_close_msec < 0)
+			time_to_close_msec = 0;
+		return time_to_close_msec;
 	}
-	else if(column_ix == col_runnersNotFinished) {
+	if(column_ix == col_runnersNotFinished) {
 		int cnt = value(row_ix, col_runnersCount).toInt() - value(row_ix, col_runnersFinished).toInt();
 		return cnt;
 	}
-	else if(column_ix == col_resultsNotPrinted) {
+	if(column_ix == col_resultsNotPrinted) {
 		int results_count = tableRow(row_ix).value(QStringLiteral("resultsCount")).toInt();
 		int cnt = value(row_ix, col_runnersFinished).toInt() - results_count;
 		return cnt;
 	}
-	else if(column_ix == col_resultsNotPrintedSec) {
+	if(column_ix == col_resultsNotPrintedSec) {
 		QDateTime dt1 = tableRow(row_ix).value(QStringLiteral("resultsPrintTS")).toDateTime();
 		QDateTime dt2 = QDateTime::currentDateTime();
 		if(!dt1.isValid())


### PR DESCRIPTION
right now solves two issues.
1) 3rd best time was incorrectly calculated even if finished runners count was less than 3 as `MAX(TOP 3)`
2) TimeToClose should now display 0 if all runners finished (even if there are less than 3), display nothing if there is no enough information to do the calculation or display calculated timeToClose down to 0.