### PR TITLE
Úprava layoutu startovních listin

### DIFF
--- a/quickevent/app/plugins/Runs/qml/reports/startList_classes.qml
+++ b/quickevent/app/plugins/Runs/qml/reports/startList_classes.qml
@@ -99,13 +99,13 @@ Report {
 							layout: Frame.LayoutHorizontal
 							function dataFn(field_name) {return function() {return rowData(field_name);}}
 							Cell {
-								width: 18
+								width: 16
 								halign: Frame.AlignRight
 								textFn: runnersDetail.dataFn("startTimeText");
 							}
 							Para {
 								visible: root.isPrintStartNumbers
-								width: 9
+								width: 8
 								halign: Frame.AlignRight
 								textFn: function() {
 									var sn = runnersDetail.dataFn("startNumber")();
@@ -117,11 +117,11 @@ Report {
 								textFn: runnersDetail.dataFn("competitorName");
 							}
 							Para {
-								width: 18
+								width: 16
 								textFn: runnersDetail.dataFn("registration");
 							}
 							Cell {
-								width: 18
+								width: 17
 								halign: Frame.AlignRight
 								textFn: runnersDetail.dataFn("runs.siId");
 							}

--- a/quickevent/app/plugins/Runs/qml/reports/startList_classes.qml
+++ b/quickevent/app/plugins/Runs/qml/reports/startList_classes.qml
@@ -123,7 +123,10 @@ Report {
 							Cell {
 								width: 17
 								halign: Frame.AlignRight
-								textFn: runnersDetail.dataFn("runs.siId");
+								textFn: function() {
+									var si = runnersDetail.dataFn("runs.siId")();
+									return si > 0 ? si : "";
+								}
 							}
 						}
 					}

--- a/quickevent/app/plugins/Runs/qml/reports/startList_clubs.qml
+++ b/quickevent/app/plugins/Runs/qml/reports/startList_clubs.qml
@@ -104,17 +104,17 @@ Report {
 							layout: Frame.LayoutHorizontal
 							function dataFn(field_name) {return function() {return rowData(field_name);}}
 							Cell {
-								width: 18
+								width: 16
 								halign: Frame.AlignRight
 								textFn: runnersDetail.dataFn("startTimeText");
 							}
 							Para {
-								width: 10
+								width: 9
 								textFn: runnersDetail.dataFn("classes.name");
 							}
 							Para {
 								visible: root.isPrintStartNumbers
-								width: 9
+								width: 7
 								halign: Frame.AlignRight
 								textFn: function() {
 									var sn = runnersDetail.dataFn("startNumber")();
@@ -126,7 +126,7 @@ Report {
 								textFn: runnersDetail.dataFn("competitorName");
 							}
 							Para {
-								width: 16
+								width: 15
 								textFn: runnersDetail.dataFn("registration");
 							}
 							Para {

--- a/quickevent/app/plugins/Runs/qml/reports/startList_clubs_nstages.qml
+++ b/quickevent/app/plugins/Runs/qml/reports/startList_clubs_nstages.qml
@@ -112,20 +112,20 @@ Report {
 						Cell {
 							visible: root.isPrintStartNumbers
 							id: hdrStartNumber
-							width: 16
+							width: 12
 							textStyle: myStyle.textStyleBold
 							halign: Frame.AlignRight
 							text: qsTr("Bib");
 						}
 						Cell {
 							id: hdrRegistration
-							width: 25
+							width: 23
 							textStyle: myStyle.textStyleBold
 							text: qsTr("Registration");
 						}
 						Cell {
 							id: hdrSI
-							width: 18
+							width: 19
 							textStyle: myStyle.textStyleBold
 							halign: Frame.AlignRight
 							text: qsTr("SI");
@@ -135,7 +135,7 @@ Report {
 							for(var i=0; i<root.stagesCount; i++) {
 								//console.warn("=============", i, qsTr("Stage") + (i+1))
 								//var runs_table = "runs" + (i+1);
-								var c = cHeaderCell.createObject(null, {"halign": Frame.AlignRight, "width": 18, "text": qsTr("Stage") + (i+1)});
+								var c = cHeaderCell.createObject(null, {"halign": Frame.AlignRight, "width": 17, "text": qsTr("Stage") + (i+1)});
 								classHeader.addItem(c);
 							}
 						}
@@ -154,7 +154,7 @@ Report {
 							layout: Frame.LayoutHorizontal
 							function dataFn(field_name) {return function() {return rowData(field_name);}}
 							Cell {
-								width: 15
+								width: 12
 								textFn: runnersDetail.dataFn("classes.name");
 							}
 							Cell {
@@ -183,7 +183,7 @@ Report {
 								//console.warn("=============", root.stageCount)
 								for(var i=0; i<root.stagesCount; i++) {
 									var runs_table = "runs" + (i+1);
-									var c = cStartTimeCell.createObject(null, {"width": 18, "halign": Frame.AlignRight, "fieldName": runs_table + ".startTimeText", "isRunning": runs_table + ".isRunning" });
+									var c = cStartTimeCell.createObject(null, {"width": 17, "halign": Frame.AlignRight, "fieldName": runs_table + ".startTimeText", "isRunning": runs_table + ".isRunning" });
 									runnersDetail.addItem(c);
 								}
 							}

--- a/quickevent/app/plugins/Runs/qml/reports/startList_starters.qml
+++ b/quickevent/app/plugins/Runs/qml/reports/startList_starters.qml
@@ -97,12 +97,12 @@ Report {
 						layout: Frame.LayoutHorizontal
 						Para {
 							objectName: "minuteCellClassName"
-							width: 12
+							width: 9
 							text: detail.data(detail.currentIndex, "classes.name");
 						}
 						Para {
 							visible: root.isPrintStartNumbers
-							width: 9
+							width: 8
 							halign: Frame.AlignRight
 							text: {
 								var sn = detail.data(detail.currentIndex,"competitors.startNumber");


### PR DESCRIPTION
Změny:
- určitým sloupcům jsem zmenšil šířku, aby při tisku startovních listin se startovními čísly nedocházelo k nežádoucímu zalamování jmen
- pokud je číslo SI čipu 0, tak není zobrazeno ve startovní listině (týká se především vakantů)