### PR TITLE
refactor autoprint

### DIFF
--- a/quickevent/app/plugins/Receipts/src/receiptsplugin.cpp
+++ b/quickevent/app/plugins/Receipts/src/receiptsplugin.cpp
@@ -423,8 +423,7 @@ bool ReceiptsPlugin::printReceipt(int card_id)
 {
 	QF_TIME_SCOPE("ReceiptsPlugin::printReceipt()");
 	try {
-		printReceipt(card_id, currentReceiptPath());
-		return true;
+		return printReceipt(card_id, currentReceiptPath());
 	}
 	catch(const qf::core::Exception &e) {
 		qfError() << e.toString();
@@ -438,8 +437,7 @@ bool ReceiptsPlugin::printCard(int card_id)
 	QF_TIME_SCOPE("ReceiptsPlugin::printCard()");
 	try {
 		QVariantMap dt = readCardTablesData(card_id);
-		receiptsPrinter()->printReceipt(manifest()->homeDir() + "/reports/sicard.qml", dt);
-		return true;
+		return receiptsPrinter()->printReceipt(manifest()->homeDir() + "/reports/sicard.qml", dt);
 	}
 	catch(const qf::core::Exception &e) {
 		qfError() << e.toString();
@@ -453,8 +451,7 @@ bool ReceiptsPlugin::printError(int card_id)
 	QF_TIME_SCOPE("ReceiptsPlugin::printError()");
 	try {
 		QVariantMap dt = readCardTablesData(card_id);
-		receiptsPrinter()->printReceipt(manifest()->homeDir() + "/reports/error.qml", dt);
-		return true;
+		return receiptsPrinter()->printReceipt(manifest()->homeDir() + "/reports/error.qml", dt);
 	}
 		catch(const qf::core::Exception &e) {
 		qfError() << e.toString();
@@ -479,11 +476,11 @@ void ReceiptsPlugin::previewReceipt(int card_id, const QString &receipt_path)
 	dlg.exec();
 }
 
-void ReceiptsPlugin::printReceipt(int card_id, const QString &receipt_path)
+bool ReceiptsPlugin::printReceipt(int card_id, const QString &receipt_path)
 {
 	qfLogFuncFrame() << "card id:" << card_id;
 	QVariantMap dt = receiptTablesData(card_id);
-	receiptsPrinter()->printReceipt(receipt_path, dt);
+	return receiptsPrinter()->printReceipt(receipt_path, dt);
 }
 
 bool ReceiptsPlugin::isAutoPrintEnabled()

--- a/quickevent/app/plugins/Receipts/src/receiptsplugin.h
+++ b/quickevent/app/plugins/Receipts/src/receiptsplugin.h
@@ -57,7 +57,7 @@ private:
 	ReceiptsPrinterOptions receiptsPrinterOptions();
 
 	void previewReceipt(int card_id, const QString &receipt_path);
-	void printReceipt(int card_id, const QString &receipt_path);
+	bool printReceipt(int card_id, const QString &receipt_path);
 	QList<QByteArray> createPrinterData(const QDomElement &body, const ReceiptsPrinterOptions &printer_options);
 
 	class DirectPrintContext;

--- a/quickevent/app/plugins/Receipts/src/receiptsprinter.cpp
+++ b/quickevent/app/plugins/Receipts/src/receiptsprinter.cpp
@@ -42,12 +42,12 @@ static Receipts::ReceiptsPlugin *receiptsPlugin()
 	return ret;
 }
 */
-void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVariantMap &report_data)
+bool ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVariantMap &report_data)
 {
 	qfLogFuncFrame();
 	if(report_file_name.isEmpty()) {
 		qfError() << "Empty receipt path.";
-		return;
+		return false;
 	}
 	QF_TIME_SCOPE("ReceiptsPrinter::printReceipt()");
 	const ReceiptsPrinterOptions &printer_opts = m_printerOptions;
@@ -64,7 +64,7 @@ void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 		}
 		if(pi.isNull()) {
 			qfWarning() << "Default printer not set";
-			return;
+			return false;
 		}
 		qfInfo() << "printing on:" << pi.printerName();
 		printer = new QPrinter(pi);
@@ -82,7 +82,7 @@ void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 	{
 		QF_TIME_SCOPE("setting report and data");
 		if(!rp.setReport(report_file_name))
-			return;
+			return false;
 		for(auto key : report_data.keys()) {
 			rp.setTableData(key, report_data.value(key));
 		}
@@ -105,8 +105,9 @@ void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 			painter.drawMetaPaint(it);
 		}
 		QF_SAFE_DELETE(printer);
+		return true;
 	}
-	else if(printer_opts.printerType() == ReceiptsPrinterOptions::PrinterType::CharacterPrinter) {
+	if(printer_opts.printerType() == ReceiptsPrinterOptions::PrinterType::CharacterPrinter) {
 		QDomDocument doc;
 		doc.setContent(QLatin1String("<?xml version=\"1.0\"?><report><body/></report>"));
 		QDomElement el_body = doc.documentElement().firstChildElement("body");
@@ -123,9 +124,11 @@ void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 					f.write(ba);
 					f.write("\n");
 				}
+				return true;
 			}
 			else {
 				qfError() << "Cannot open file" << f.fileName() << "for writing!";
+				return false;
 			}
 		};
 		switch(printer_opts.characterPrinterType()) {
@@ -137,15 +140,15 @@ void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 					for(QByteArray ba : data_lines)
 						ch.addData(ba);
 					fn += '/' + QString::fromLatin1(ch.result().toHex().mid(0, 8)) + ".txt";
-					save_file(fn);
+					return save_file(fn);
 				}
-				break;
+				return false;
 			}
 			case ReceiptsPrinterOptions::CharacterPrinteType::LPT: {
 				if (!printer_opts.characterPrinterDevice().isEmpty()) {
-					save_file(printer_opts.characterPrinterDevice());
+					return save_file(printer_opts.characterPrinterDevice());
 				}
-				break;
+				return false;
 			}
 			case ReceiptsPrinterOptions::CharacterPrinteType::Network: {
 				if (!printer_opts.characterPrinterUrl().isEmpty()) {
@@ -163,6 +166,7 @@ void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 						dgram += "\n\n\n";
 						QUdpSocket socket;
 						socket.writeDatagram(dgram, host_addr, port);
+						return true;
 					}
 					else {
 						QTcpSocket socket;
@@ -176,19 +180,24 @@ void ReceiptsPrinter::printReceipt(const QString &report_file_name, const QVaria
 							if (!socket.waitForDisconnected(1000)) { // waiting till all data are sent
 								qfError() << "Error while closing the connection to printer: "
 										<< socket.error();
+								return false;
 							}
+							return true;
 						}
 						else {
 							qfError() << "Cannot open tcp connection to address "
 									<< host << " on port " << port
 									<< " reason: " << socket.error();
+							return false;
 						}
 					}
 				}
-				break;
+				return false;
 			}
 		}
 	}
+	qfError() << "Unknow printer type";
+	return false;
 }
 
 static const QByteArray epson_commands[] =

--- a/quickevent/app/plugins/Receipts/src/receiptsprinter.h
+++ b/quickevent/app/plugins/Receipts/src/receiptsprinter.h
@@ -16,7 +16,7 @@ public:
 
 	const ReceiptsPrinterOptions& printerOptions() const {return m_printerOptions;}
 
-	void printReceipt(const QString &report_file_name, const QVariantMap &report_data);
+	bool printReceipt(const QString &report_file_name, const QVariantMap &report_data);
 private:
 	QList<QByteArray> createPrinterData(const QDomElement &body, const ReceiptsPrinterOptions &printer_options);
 	void createPrinterData_helper(const QDomElement &el, DirectPrintContext *print_context, const QString &text_encoding);

--- a/quickevent/app/plugins/Receipts/src/receiptswidget.cpp
+++ b/quickevent/app/plugins/Receipts/src/receiptswidget.cpp
@@ -176,7 +176,8 @@ void ReceiptsWidget::onDbEventNotify(const QString &domain, int connection_id, c
 	Q_UNUSED(connection_id)
 	Q_UNUSED(data)
 	if(domain == QLatin1String(Event::EventPlugin::DBEVENT_CARD_READ)) {
-		onCardRead();
+		int card_id = data.toInt();
+		onCardRead(connection_id, card_id);
 	}
 }
 
@@ -202,39 +203,34 @@ int ReceiptsWidget::currentStageId()
 	return ret;
 }
 
-void ReceiptsWidget::onCardRead()
+void ReceiptsWidget::onCardRead(int connection_id, int card_id)
 {
 	if(isAutoPrintEnabled()) {
-		printNewCards();
+		if(!thisReaderOnly() || connection_id == currentConnectionId()) {
+			printReceipt(card_id);
+		}
 	}
 	loadNewCards();
 }
 
 void ReceiptsWidget::printNewCards()
 {
-	auto conn  = qf::core::sql::Connection::forName();
-	int connection_id = conn.connectionId();
+	int connection_id = currentConnectionId();
 	QF_ASSERT(connection_id > 0, "Cannot get SQL connection id", return);
 	int current_stage = currentStageId();
-	QString qs = "UPDATE cards SET printerConnectionId=" QF_IARG(connection_id)
+	qf::core::sql::Query q;
+	QString qs = "SELECT id FROM cards"
 			" WHERE printerConnectionId IS NULL"
-			" AND cards.stageId=" QF_IARG(current_stage);
+			" AND stageId=" QF_IARG(current_stage);
 	if(ui->chkThisReaderOnly->isChecked()) {
 		qs += " AND readerConnectionId=" QF_IARG(connection_id);
 	}
-	qf::core::sql::Query q(conn);
-	q.exec(qs, qf::core::Exception::Throw);
-	int num_rows = q.numRowsAffected();
-	if(num_rows > 0) {
-		qs = "SELECT id FROM cards WHERE printerConnectionId=" QF_IARG(connection_id)
-				" ORDER BY id DESC"
-				" LIMIT " QF_IARG(num_rows);
-		q.exec(qs, qf::core::Exception::Throw);
-		while(q.next()) {
-			int card_id = q.value(0).toInt();
-			if(!printReceipt(card_id))
-				break;
-		}
+	qs += " ORDER BY id DESC";
+	q.execThrow(qs);
+	while(q.next()) {
+		int card_id = q.value(0).toInt();
+		if(!printReceipt(card_id))
+			break;
 	}
 }
 
@@ -278,22 +274,35 @@ void ReceiptsWidget::printSelectedCards()
 
 bool ReceiptsWidget::printReceipt(int card_id)
 {
+	int connection_id = currentConnectionId();
+	QF_ASSERT(connection_id > 0, "Cannot get SQL connection id", return false);
+	bool ok = false;
 	qf::core::sql::Query q;
-	if(q.exec("SELECT runId FROM cards WHERE id=" QF_IARG(card_id))) {
+	if(q.execThrow("SELECT runId FROM cards WHERE id=" QF_IARG(card_id))) {
 		if(q.next()) {
 			int run_id = q.value(0).toInt();
 			if(run_id > 0)
-				return receiptsPlugin()->printReceipt(card_id);
+				ok = receiptsPlugin()->printReceipt(card_id);
 			else
 			{
 				if (ui->lstNotFound->currentIndex() == 0)
-					return receiptsPlugin()->printError(card_id);
+					ok = receiptsPlugin()->printError(card_id);
 				else
-					return receiptsPlugin()->printCard(card_id);
+					ok = receiptsPlugin()->printCard(card_id);
 			}
 		}
 	}
-	return false;
+	if(ok)
+		markAsPrinted(connection_id, card_id);
+	return ok;
+}
+
+void ReceiptsWidget::markAsPrinted(int connection_id, int card_id)
+{
+	QString qs = "UPDATE cards SET printerConnectionId=" QF_IARG(connection_id)
+			" WHERE id == " QF_IARG(card_id);
+	qf::core::sql::Query q;
+	q.execThrow(qs);
 }
 
 void ReceiptsWidget::loadReceptList()
@@ -350,4 +359,13 @@ void ReceiptsWidget::on_btPrinterOptions_clicked()
 bool ReceiptsWidget::isAutoPrintEnabled()
 {
 	return ui->chkAutoPrint->isChecked();
+}
+
+int ReceiptsWidget::currentConnectionId()
+{
+	return qf::core::sql::Connection::forName().connectionId();
+}
+
+bool ReceiptsWidget::thisReaderOnly() {
+	return ui->chkThisReaderOnly->isChecked();
 }

--- a/quickevent/app/plugins/Receipts/src/receiptswidget.h
+++ b/quickevent/app/plugins/Receipts/src/receiptswidget.h
@@ -56,12 +56,13 @@ private:
 
 	Receipts::ReceiptsPlugin* receiptsPlugin();
 	Event::EventPlugin* eventPlugin();
-	void onCardRead();
+	void onCardRead(int connection_id, int card_id);
 	void printNewCards();
 	void loadNewCards();
 	Q_SLOT void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
 
 	bool printReceipt(int card_id);
+	void markAsPrinted(int connection_id, int card_id);
 
 	void lazyInit();
 	void loadReceptList();
@@ -69,6 +70,8 @@ private:
 
 	void createActions();
 	int currentStageId();
+	int currentConnectionId();
+	bool thisReaderOnly();
 private:
 	Ui::ReceiptsWidget *ui;
 	qf::core::model::SqlTableModel *m_cardsModel = nullptr;


### PR DESCRIPTION
1) change `autoprint` feature to print only the currently inserted SI Card, resolve #503 (use `print new` if you want to print all unprinted receipts so far)
2) mark receipt as *successfully printed* only if error was not encountered during the process (failed to print receipts can now be more easily printed using the `print new` button, once the issue with printer is resolved)