### PR TITLE
set Ok button as default in connect to db dialog

### DIFF
--- a/libqf/libqfqmlwidgets/src/dialogs/dialog.cpp
+++ b/libqf/libqfqmlwidgets/src/dialogs/dialog.cpp
@@ -331,8 +331,10 @@ void Dialog::setDefaultButton(int standard_button)
 	DialogButtonBox *bbx = buttonBox();
 	if(bbx) {
 		bt = bbx->button((QDialogButtonBox::StandardButton)standard_button);
-		if(bt)
+		if(bt) {
 			bt->setDefault(true);
+			bt->setFocus();
+		}
 	}
 	QF_CHECK(bt != nullptr, QString("Cannot find standard button: %1").arg(standard_button));
 }

--- a/quickevent/app/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/plugins/Event/src/eventplugin.cpp
@@ -630,6 +630,7 @@ void EventPlugin::connectToSqlServer()
 
 	qfd::Dialog dlg(fwk);
 	dlg.setButtons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+	dlg.setDefaultButton(QDialogButtonBox::Ok);
 	dlg.setSavePersistentPosition(false);
 	ConnectDbDialogWidget *conn_w = new ConnectDbDialogWidget();
 	dlg.setCentralWidget(conn_w);


### PR DESCRIPTION
make Ok button the default in the connectToSqlServer/ConnectDbDialogWidget, so one can open the event just by pressing enter, when the application starts