### PR TITLE
Add qtbase translations

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -119,7 +119,13 @@ jobs:
           echo "$QT_DIR/bin/lrelease $tsfile -qm $TRANS_DIR/$qmfile"
           $Qt5_Dir/bin/lrelease $tsfile -qm $TRANS_DIR/$qmfile
         done
-      
+
+        LANGUAGES=("cs_CZ" "fr_FR" "nb_NO" "nl_BE" "pl_PL" "ru_RU" "uk_UA")
+        for language in ${LANGUAGES[@]} ; do
+          # some languages don't have qtbase file translated
+          cp --verbose "${Qt5_Dir}/translations/qtbase_${language:0:2}.qm" "${TRANS_DIR}/qtbase.${language}.qm" || true
+        done
+
     - name: Get app version
       run: echo "VERSION=`grep APP_VERSION quickevent/app/quickevent/src/appversion.h | cut -d\\" -f2`" >> $GITHUB_ENV
   

--- a/build-win.sh
+++ b/build-win.sh
@@ -13,6 +13,12 @@ for tsfile in `/usr/bin/find . -name "*.ts"` ; do
 	$QT_DIR/bin/lrelease $tsfile -qm $TRANS_DIR/$qmfile
 done
 
+LANGUAGES=("cs_CZ" "fr_FR" "nb_NO" "nl_BE" "pl_PL" "ru_RU" "uk_UA")
+for language in ${LANGUAGES[@]} ; do
+	# some languages don't have qtbase file translated
+	cp --verbose "${QT_DIR}/translations/qtbase_${language:0:2}.qm" "${TRANS_DIR}/qtbase.${language}.qm" || true
+done
+
 QUICKEVENT_VERSION=`grep APP_VERSION quickevent/app/quickevent/src/appversion.h | cut -d\" -f2`
 
 "C:\Program Files (x86)\Inno Setup 5\iscc.exe" "-DVERSION=${QUICKEVENT_VERSION}" quickevent/quickevent.iss  || exit 2

--- a/quickevent/app/quickevent/src/main.cpp
+++ b/quickevent/app/quickevent/src/main.cpp
@@ -112,19 +112,8 @@ int main(int argc, char *argv[])
 			lc_name = QLocale::system().name();
 		QString app_translations_path = QCoreApplication::applicationDirPath() + "/translations";
 		qfInfo() << "Loading translations for:" << lc_name;
-		{
-			QTranslator *qt_translator = new QTranslator(&app);
-			QString tr_name = "qt_" + lc_name;
-			bool ok = qt_translator->load(tr_name, app_translations_path);
-			if(ok) {
-				ok = app.installTranslator(qt_translator);
-				qfInfo() << "Installing translator file:" << tr_name << " ... " << (ok? "OK": "ERROR");
-			}
-			else {
-				qfInfo() << "Erorr loading translator file:" << (app_translations_path + '/' + tr_name);
-			}
-		}
-		for(QString prefix : {"libqfcore", "libqfqmlwidgets", "libquickeventcore", "libquickeventgui", "libsiut", "quickevent"}) {
+
+		for(QString prefix : {"qtbase", "libqfcore", "libqfqmlwidgets", "libquickeventcore", "libquickeventgui", "libsiut", "quickevent"}) {
 			QTranslator *qt_translator = new QTranslator(&app);
 			QString tr_name = prefix + "." + lc_name;
 			bool ok = qt_translator->load(tr_name, app_translations_path);
@@ -133,7 +122,7 @@ int main(int argc, char *argv[])
 				qfInfo() << "Installing translator file:" << tr_name << " ... " << (ok? "OK": "ERROR");
 			}
 			else {
-				qfInfo() << "Erorr loading translator file:" << (app_translations_path + '/' + tr_name);
+				qfInfo() << "Error loading translator file:" << (app_translations_path + '/' + tr_name);
 			}
 		}
 	}

--- a/quickevent/make-dist.sh
+++ b/quickevent/make-dist.sh
@@ -203,6 +203,12 @@ for tsfile in `/usr/bin/find $SRC_DIR -name "*.ts"` ; do
 	$QT_DIR/bin/lrelease $tsfile -qm $TRANS_DIR/$qmfile
 done
 
+LANGUAGES=("cs_CZ" "fr_FR" "nb_NO" "nl_BE" "pl_PL" "ru_RU" "uk_UA")
+for language in ${LANGUAGES[@]} ; do
+	# some languages don't have qtbase file translated
+	cp --verbose "${QT_DIR}/translations/qtbase_${language:0:2}.qm" "${TRANS_DIR}/qtbase.${language}.qm" || true
+done
+
 ARTIFACTS_DIR=$WORK_DIR/artifacts
 mkdir -p $ARTIFACTS_DIR
 


### PR DESCRIPTION
In currently used QT version there are no translations in qt_xxx.qm file, most of them were probably moved to qtbase_xxx.qm

This PR reflects this change and copies these translations into the QE translations folder.

I hope I didn't miss some build script which is still being used.