### PR TITLE
Update Qt version in GitHub actions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  QT_VERSION: '5.15.2'
+
 jobs:
   build_linux:
     runs-on: ubuntu-latest
@@ -19,13 +22,13 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ runner.workspace }}/Qt
-        key: ${{ runner.os }}-Qt
+        key: ${{ runner.os }}-Qt-${{ env.QT_VERSION }}
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
-        version: '5.15.0'
+        version: ${{ env.QT_VERSION }}
         host: 'linux'
         
     - name: Get app version
@@ -93,13 +96,13 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ${{ runner.workspace }}\Qt
-        key: ${{ runner.os }}-Qt
+        key: ${{ runner.os }}-Qt-${{ env.QT_VERSION }}
  
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       with:
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
-        version: '5.15.0'
+        version: ${{ env.QT_VERSION }}
         host: 'windows'
         arch: 'win64_mingw81' 
     


### PR DESCRIPTION
Use latest open source Qt 5.15.x version in GitHub actions. Newer Qt 5.15.x versions are avaible just for commercial licences.