### PR TITLE
Oprava exportu pro EmmaClienta

### DIFF
--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
@@ -192,6 +192,18 @@ void EmmaClient::exportResultsIofXml3()
 	getPlugin<RunsPlugin>()->exportResultsIofXml30Stage(current_stage, file_name);
 }
 
+void EmmaClient::exportStartListIofXml3()
+{
+	if(!createExportDir())
+		return;
+	QString event_name = getPlugin<EventPlugin>()->eventName();
+	EmmaClientSettings ss = settings();
+	QString export_dir = ss.exportDir();
+	QString file_name = export_dir + '/' + event_name + ".startlist.xml";
+	int current_stage = getPlugin<EventPlugin>()->currentStageId();
+	getPlugin<RunsPlugin>()->exportStartListStageIofXml30(current_stage, file_name);
+}
+
 bool EmmaClient::createExportDir()
 {
 	EmmaClientSettings ss = settings();
@@ -289,9 +301,14 @@ void EmmaClient::onExportTimerTimeOut()
 
 	EmmaClientSettings ss = settings();
 
-	if (ss.exportTypeXML3())
+	if (ss.exportStartTypeXML3())
 	{
-		qfInfo() << "EmmaClient Iof Xml3 creation called";
+		qfInfo() << "EmmaClient Start Iof Xml3 creation called";
+		exportStartListIofXml3();
+	}
+	if (ss.exportResultTypeXML3())
+	{
+		qfInfo() << "EmmaClient Result Iof Xml3 creation called";
 		exportResultsIofXml3();
 	}
 	if (ss.exportStart())

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
@@ -103,10 +103,11 @@ void EmmaClient::exportRadioCodes()
 			{
 				qfs::QueryBuilder qb_codes;
 				qb_codes.select2("codes", "*")
-						.from("coursecodes, courses")
-						.joinRestricted("coursecodes.codeId", "codes.id", "codes.radio", qfs::QueryBuilder::INNER_JOIN)
+						.from("coursecodes, courses, codes")
+						.where("coursecodes.codeId=codes.id")
 						.where("coursecodes.courseId=courses.id")
-						.where("courses.name=" + QString("%1.%2").arg(relayStartNumber).arg(leg))
+						.where("courses.name=" + QString("'%1.%2'").arg(relayStartNumber).arg(leg))
+						.where("codes.radio")
 						.orderBy("coursecodes.position");
 //				qfInfo() << qb_codes.toString();
 

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
@@ -60,21 +60,20 @@ QString EmmaClient::serviceName()
 	return QStringLiteral("EmmaClient");
 }
 
-void EmmaClient::exportRadioCodes()
+void EmmaClient::exportRadioCodesRacomTxt()
 {
 	EmmaClientSettings ss = settings();
 	QString export_dir = ss.exportDir();
 	if(!createExportDir()) {
 		return;
 	}
-	QString event_name = getPlugin<EventPlugin>()->eventName();
-	QFile f_splitnames(export_dir + '/' + event_name + ".splitnames.txt");
+	QFile f_splitnames(export_dir + '/' + ss.fileName() + ".splitnames.txt");
 	if(!f_splitnames.open(QFile::WriteOnly)) {
 		qfError() << "Canot open file:" << f_splitnames.fileName() << "for writing.";
 		return;
 	}
 	qfInfo() << "EmmaClient: exporting code names to" << f_splitnames.fileName();
-	QFile f_splitcodes(ss.exportDir() + '/' + event_name + ".splitcodes.txt");
+	QFile f_splitcodes(ss.exportDir() + '/' + ss.fileName() + ".splitcodes.txt");
 	if(!f_splitcodes.open(QFile::WriteOnly)) {
 		qfError() << "Canot open file:" << f_splitcodes.fileName() << "for writing.";
 		return;
@@ -184,10 +183,9 @@ void EmmaClient::exportResultsIofXml3()
 {
 	if(!createExportDir())
 		return;
-	QString event_name = getPlugin<EventPlugin>()->eventName();
 	EmmaClientSettings ss = settings();
 	QString export_dir = ss.exportDir();
-	QString file_name = export_dir + '/' + event_name + ".results.xml";
+	QString file_name = export_dir + '/' + ss.fileName() + ".results.xml";
 	int current_stage = getPlugin<EventPlugin>()->currentStageId();
 	getPlugin<RunsPlugin>()->exportResultsIofXml30Stage(current_stage, file_name);
 }
@@ -196,10 +194,9 @@ void EmmaClient::exportStartListIofXml3()
 {
 	if(!createExportDir())
 		return;
-	QString event_name = getPlugin<EventPlugin>()->eventName();
 	EmmaClientSettings ss = settings();
 	QString export_dir = ss.exportDir();
-	QString file_name = export_dir + '/' + event_name + ".startlist.xml";
+	QString file_name = export_dir + '/' + ss.fileName() + ".startlist.xml";
 	int current_stage = getPlugin<EventPlugin>()->currentStageId();
 	getPlugin<RunsPlugin>()->exportStartListStageIofXml30(current_stage, file_name);
 }
@@ -311,19 +308,19 @@ void EmmaClient::onExportTimerTimeOut()
 		qfInfo() << "EmmaClient Result Iof Xml3 creation called";
 		exportResultsIofXml3();
 	}
-	if (ss.exportStart())
+	if (ss.exportStartTypeTxt())
 	{
 		qfInfo() << "EmmaClient startlist creation called";
-		exportStartList();
+		exportStartListRacomTxt();
 	}
-	if (ss.exportFinish())
+	if (ss.exportFinishTypeTxt())
 	{
 		qfInfo() << "EmmaClient finish creation called";
-		exportFinish();
+		exportFinishRacomTxt();
 	}
 }
 
-void EmmaClient::exportFinish()
+void EmmaClient::exportFinishRacomTxt()
 {
 	EmmaClientSettings ss = settings();
 	QString export_dir = ss.exportDir();
@@ -395,7 +392,7 @@ void EmmaClient::exportFinish()
 	}
 }
 
-void EmmaClient::exportStartList()
+void EmmaClient::exportStartListRacomTxt()
 {
 	EmmaClientSettings ss = settings();
 	QString export_dir = ss.exportDir();

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
@@ -67,13 +67,13 @@ void EmmaClient::exportRadioCodesRacomTxt()
 	if(!createExportDir()) {
 		return;
 	}
-	QFile f_splitnames(export_dir + '/' + ss.fileName() + ".splitnames.txt");
+	QFile f_splitnames(export_dir + '/' + ss.fileNameBase() + ".splitnames.txt");
 	if(!f_splitnames.open(QFile::WriteOnly)) {
 		qfError() << "Canot open file:" << f_splitnames.fileName() << "for writing.";
 		return;
 	}
 	qfInfo() << "EmmaClient: exporting code names to" << f_splitnames.fileName();
-	QFile f_splitcodes(ss.exportDir() + '/' + ss.fileName() + ".splitcodes.txt");
+	QFile f_splitcodes(ss.exportDir() + '/' + ss.fileNameBase() + ".splitcodes.txt");
 	if(!f_splitcodes.open(QFile::WriteOnly)) {
 		qfError() << "Canot open file:" << f_splitcodes.fileName() << "for writing.";
 		return;
@@ -185,7 +185,7 @@ void EmmaClient::exportResultsIofXml3()
 		return;
 	EmmaClientSettings ss = settings();
 	QString export_dir = ss.exportDir();
-	QString file_name = export_dir + '/' + ss.fileName() + ".results.xml";
+	QString file_name = export_dir + '/' + ss.fileNameBase() + ".results.xml";
 	int current_stage = getPlugin<EventPlugin>()->currentStageId();
 	getPlugin<RunsPlugin>()->exportResultsIofXml30Stage(current_stage, file_name);
 }
@@ -196,7 +196,7 @@ void EmmaClient::exportStartListIofXml3()
 		return;
 	EmmaClientSettings ss = settings();
 	QString export_dir = ss.exportDir();
-	QString file_name = export_dir + '/' + ss.fileName() + ".startlist.xml";
+	QString file_name = export_dir + '/' + ss.fileNameBase() + ".startlist.xml";
 	int current_stage = getPlugin<EventPlugin>()->currentStageId();
 	getPlugin<RunsPlugin>()->exportStartListStageIofXml30(current_stage, file_name);
 }
@@ -298,12 +298,12 @@ void EmmaClient::onExportTimerTimeOut()
 
 	EmmaClientSettings ss = settings();
 
-	if (ss.exportStartTypeXML3())
+	if (ss.exportStartListTypeXml3())
 	{
-		qfInfo() << "EmmaClient Start Iof Xml3 creation called";
+		qfInfo() << "EmmaClient Start List Iof Xml3 creation called";
 		exportStartListIofXml3();
 	}
-	if (ss.exportResultTypeXML3())
+	if (ss.exportResultTypeXml3())
 	{
 		qfInfo() << "EmmaClient Result Iof Xml3 creation called";
 		exportResultsIofXml3();
@@ -324,7 +324,7 @@ void EmmaClient::exportFinishRacomTxt()
 {
 	EmmaClientSettings ss = settings();
 	QString export_dir = ss.exportDir();
-	QFile f(export_dir + '/' + ss.fileName() + ".finish.txt");
+	QFile f(export_dir + '/' + ss.fileNameBase() + ".finish.txt");
 	if(!f.open(QFile::WriteOnly)) {
 		qfError() << "Canot open file:" << f.fileName() << "for writing.";
 		return;
@@ -396,7 +396,7 @@ void EmmaClient::exportStartListRacomTxt()
 {
 	EmmaClientSettings ss = settings();
 	QString export_dir = ss.exportDir();
-	QFile f(export_dir + '/' + ss.fileName() + ".start.txt");
+	QFile f(export_dir + '/' + ss.fileNameBase() + ".start.txt");
 	if(!f.open(QFile::WriteOnly)) {
 		qfError() << "Canot open file:" << f.fileName() << "for writing.";
 		return;

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.h
@@ -16,8 +16,8 @@ class EmmaClientSettings : public ServiceSettings
 	QF_VARIANTMAP_FIELD(QString, e, setE, xportDir)
 	QF_VARIANTMAP_FIELD(QString, f, setF, ileName)
 	QF_VARIANTMAP_FIELD2(int, e, setE, xportIntervalSec, 0)
-	QF_VARIANTMAP_FIELD2(bool, e, setE, xportStart, 0)
-	QF_VARIANTMAP_FIELD2(bool, e, setE, xportFinish, 0)
+	QF_VARIANTMAP_FIELD2(bool, e, setE, xportStartTypeTxt, 0)
+	QF_VARIANTMAP_FIELD2(bool, e, setE, xportFinishTypeTxt, 0)
 public:
 	EmmaClientSettings(const QVariantMap &o = QVariantMap()) : Super(o) {}
 };
@@ -36,11 +36,11 @@ public:
 
 	static QString serviceName();
 
-	void exportRadioCodes();
+	void exportRadioCodesRacomTxt();
 	void exportResultsIofXml3();
 	void exportStartListIofXml3();
-	void exportFinish();
-	void exportStartList();
+	void exportFinishRacomTxt();
+	void exportStartListRacomTxt();
 	bool preExport();
 	void loadSettings() override;
 private:

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.h
@@ -11,7 +11,8 @@ class EmmaClientSettings : public ServiceSettings
 {
 	using Super = ServiceSettings;
 
-	QF_VARIANTMAP_FIELD2(bool, e, setE, xportTypeXML3, 0)
+	QF_VARIANTMAP_FIELD2(bool, e, setE, xportStartTypeXML3, 0)
+	QF_VARIANTMAP_FIELD2(bool, e, setE, xportResultTypeXML3, 0)
 	QF_VARIANTMAP_FIELD(QString, e, setE, xportDir)
 	QF_VARIANTMAP_FIELD(QString, f, setF, ileName)
 	QF_VARIANTMAP_FIELD2(int, e, setE, xportIntervalSec, 0)
@@ -37,6 +38,7 @@ public:
 
 	void exportRadioCodes();
 	void exportResultsIofXml3();
+	void exportStartListIofXml3();
 	void exportFinish();
 	void exportStartList();
 	bool preExport();

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.h
@@ -11,10 +11,10 @@ class EmmaClientSettings : public ServiceSettings
 {
 	using Super = ServiceSettings;
 
-	QF_VARIANTMAP_FIELD2(bool, e, setE, xportStartTypeXML3, 0)
-	QF_VARIANTMAP_FIELD2(bool, e, setE, xportResultTypeXML3, 0)
+	QF_VARIANTMAP_FIELD2(bool, e, setE, xportStartListTypeXml3, 0)
+	QF_VARIANTMAP_FIELD2(bool, e, setE, xportResultTypeXml3, 0)
 	QF_VARIANTMAP_FIELD(QString, e, setE, xportDir)
-	QF_VARIANTMAP_FIELD(QString, f, setF, ileName)
+	QF_VARIANTMAP_FIELD(QString, f, setF, ileNameBase)
 	QF_VARIANTMAP_FIELD2(int, e, setE, xportIntervalSec, 0)
 	QF_VARIANTMAP_FIELD2(bool, e, setE, xportStartTypeTxt, 0)
 	QF_VARIANTMAP_FIELD2(bool, e, setE, xportFinishTypeTxt, 0)

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.cpp
@@ -25,22 +25,22 @@ EmmaClientWidget::EmmaClientWidget(QWidget *parent)
 	if(svc) {
 		EmmaClientSettings ss = svc->settings();
 		ui->edExportDir->setText(ss.exportDir());
-		ui->edFileName->setText(ss.fileName());
+		ui->edFileNameBase->setText(ss.fileNameBase());
 		ui->edExportInterval->setValue(ss.exportIntervalSec());
-		ui->chExportStartTxt->setCheckState((ss.exportStartTypeTxt()) ? Qt::Checked : Qt::Unchecked);
+		ui->chExportStartListTxt->setCheckState((ss.exportStartTypeTxt()) ? Qt::Checked : Qt::Unchecked);
 		ui->chExportFinishTxt->setCheckState((ss.exportFinishTypeTxt()) ? Qt::Checked : Qt::Unchecked);
-		ui->chExportStartXML30->setCheckState((ss.exportStartTypeXML3()) ? Qt::Checked : Qt::Unchecked);
-		ui->chExportResultsXML30->setCheckState((ss.exportResultTypeXML3()) ? Qt::Checked : Qt::Unchecked);
-		if (ui->edFileName->text().isEmpty())
-			ui->edFileName->setText(getPlugin<EventPlugin>()->eventName());
+		ui->chExportStartListXml30->setCheckState((ss.exportStartListTypeXml3()) ? Qt::Checked : Qt::Unchecked);
+		ui->chExportResultsXml30->setCheckState((ss.exportResultTypeXml3()) ? Qt::Checked : Qt::Unchecked);
+		if (ui->edFileNameBase->text().isEmpty())
+			ui->edFileNameBase->setText(getPlugin<EventPlugin>()->eventName());
 	}
 
 	connect(ui->btChooseExportDir, &QPushButton::clicked, this, &EmmaClientWidget::onBtChooseExportDirClicked);
 	connect(ui->btExportSplitsTxt, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportSplitsTxtClicked);
 	connect(ui->btExportFinishTxt, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportFinishTxtClicked);
-	connect(ui->btExportStartTxt, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportStartTxtClicked);
-	connect(ui->btExportResultsXML30, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportResultsXML30Clicked);
-	connect(ui->btExportStartXML30, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportStartXML30Clicked);
+	connect(ui->btExportStartListTxt, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportStartListTxtClicked);
+	connect(ui->btExportResultsXml30, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportResultsXml30Clicked);
+	connect(ui->btExportStartListXml30, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportStartListXml30Clicked);
 }
 
 EmmaClientWidget::~EmmaClientWidget()
@@ -94,13 +94,13 @@ bool EmmaClientWidget::saveSettings()
 		QString dir = ui->edExportDir->text().trimmed();
 		ss.setExportDir(dir);
 		ss.setExportIntervalSec(ui->edExportInterval->value());
-		ss.setFileName(ui->edFileName->text().trimmed());
-		ss.setExportStartTypeTxt(ui->chExportStartTxt->isChecked());
+		ss.setFileNameBase(ui->edFileNameBase->text().trimmed());
+		ss.setExportStartTypeTxt(ui->chExportStartListTxt->isChecked());
 		ss.setExportFinishTypeTxt(ui->chExportFinishTxt->isChecked());
-		ss.setExportStartTypeXML3(ui->chExportStartXML30->isChecked());;
-		ss.setExportResultTypeXML3(ui->chExportResultsXML30->isChecked());;
-		if (ss.fileName().isEmpty())
-			ss.setFileName(getPlugin<EventPlugin>()->eventName());
+		ss.setExportStartListTypeXml3(ui->chExportStartListXml30->isChecked());;
+		ss.setExportResultTypeXml3(ui->chExportResultsXml30->isChecked());;
+		if (ss.fileNameBase().isEmpty())
+			ss.setFileNameBase(getPlugin<EventPlugin>()->eventName());
 
 		svc->setSettings(ss);
 		if(!dir.isEmpty()) {
@@ -120,7 +120,7 @@ void EmmaClientWidget::onBtExportFinishTxtClicked()
 	}
 }
 
-void EmmaClientWidget::onBtExportStartTxtClicked()
+void EmmaClientWidget::onBtExportStartListTxtClicked()
 {
 	EmmaClient *svc = service();
 	if(svc) {
@@ -129,7 +129,7 @@ void EmmaClientWidget::onBtExportStartTxtClicked()
 	}
 }
 
-void EmmaClientWidget::onBtExportResultsXML30Clicked()
+void EmmaClientWidget::onBtExportResultsXml30Clicked()
 {
 	EmmaClient *svc = service();
 	if(svc) {
@@ -138,7 +138,7 @@ void EmmaClientWidget::onBtExportResultsXML30Clicked()
 	}
 }
 
-void EmmaClientWidget::onBtExportStartXML30Clicked()
+void EmmaClientWidget::onBtExportStartListXml30Clicked()
 {
 	EmmaClient *svc = service();
 	if(svc) {

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.cpp
@@ -1,12 +1,15 @@
 #include "emmaclientwidget.h"
 #include "ui_emmaclientwidget.h"
 #include "emmaclient.h"
+#include "../eventplugin.h"
+#include <qf/qmlwidgets/framework/mainwindow.h>
 
 #include <qf/qmlwidgets/dialogs/messagebox.h>
 
 #include <qf/core/assert.h>
 
 #include <QFileDialog>
+using qf::qmlwidgets::framework::getPlugin;
 
 namespace Event {
 namespace services {
@@ -24,17 +27,19 @@ EmmaClientWidget::EmmaClientWidget(QWidget *parent)
 		ui->edExportDir->setText(ss.exportDir());
 		ui->edFileName->setText(ss.fileName());
 		ui->edExportInterval->setValue(ss.exportIntervalSec());
-		ui->chExportStart->setCheckState((ss.exportStart()) ? Qt::Checked : Qt::Unchecked);
-		ui->chExportFinish->setCheckState((ss.exportFinish()) ? Qt::Checked : Qt::Unchecked);
+		ui->chExportStartTxt->setCheckState((ss.exportStartTypeTxt()) ? Qt::Checked : Qt::Unchecked);
+		ui->chExportFinishTxt->setCheckState((ss.exportFinishTypeTxt()) ? Qt::Checked : Qt::Unchecked);
 		ui->chExportStartXML30->setCheckState((ss.exportStartTypeXML3()) ? Qt::Checked : Qt::Unchecked);
-		ui->chExportXML30->setCheckState((ss.exportResultTypeXML3()) ? Qt::Checked : Qt::Unchecked);
+		ui->chExportResultsXML30->setCheckState((ss.exportResultTypeXML3()) ? Qt::Checked : Qt::Unchecked);
+		if (ui->edFileName->text().isEmpty())
+			ui->edFileName->setText(getPlugin<EventPlugin>()->eventName());
 	}
 
 	connect(ui->btChooseExportDir, &QPushButton::clicked, this, &EmmaClientWidget::onBtChooseExportDirClicked);
-	connect(ui->btExportSplits, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportSplitsClicked);
-	connect(ui->btExportFinish, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportFinishClicked);
-	connect(ui->btExportStart, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportStartClicked);
-	connect(ui->btExportXML30, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportXML30Clicked);
+	connect(ui->btExportSplitsTxt, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportSplitsTxtClicked);
+	connect(ui->btExportFinishTxt, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportFinishTxtClicked);
+	connect(ui->btExportStartTxt, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportStartTxtClicked);
+	connect(ui->btExportResultsXML30, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportResultsXML30Clicked);
 	connect(ui->btExportStartXML30, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportStartXML30Clicked);
 }
 
@@ -54,12 +59,12 @@ void EmmaClientWidget::onBtChooseExportDirClicked()
 	}
 }
 
-void EmmaClientWidget::onBtExportSplitsClicked()
+void EmmaClientWidget::onBtExportSplitsTxtClicked()
 {
 	EmmaClient *svc = service();
 	if(svc) {
 		saveSettings();
-		svc->exportRadioCodes();
+		svc->exportRadioCodesRacomTxt();
 	}
 }
 
@@ -90,10 +95,13 @@ bool EmmaClientWidget::saveSettings()
 		ss.setExportDir(dir);
 		ss.setExportIntervalSec(ui->edExportInterval->value());
 		ss.setFileName(ui->edFileName->text().trimmed());
-		ss.setExportStart(ui->chExportStart->isChecked());
-		ss.setExportFinish(ui->chExportFinish->isChecked());
+		ss.setExportStartTypeTxt(ui->chExportStartTxt->isChecked());
+		ss.setExportFinishTypeTxt(ui->chExportFinishTxt->isChecked());
 		ss.setExportStartTypeXML3(ui->chExportStartXML30->isChecked());;
-		ss.setExportResultTypeXML3(ui->chExportXML30->isChecked());;
+		ss.setExportResultTypeXML3(ui->chExportResultsXML30->isChecked());;
+		if (ss.fileName().isEmpty())
+			ss.setFileName(getPlugin<EventPlugin>()->eventName());
+
 		svc->setSettings(ss);
 		if(!dir.isEmpty()) {
 			if(!QDir().mkpath(dir))
@@ -103,25 +111,25 @@ bool EmmaClientWidget::saveSettings()
 	return true;
 }
 
-void EmmaClientWidget::onBtExportFinishClicked()
+void EmmaClientWidget::onBtExportFinishTxtClicked()
 {
 	EmmaClient *svc = service();
 	if(svc) {
 		saveSettings();
-		svc->exportFinish();
+		svc->exportFinishRacomTxt();
 	}
 }
 
-void EmmaClientWidget::onBtExportStartClicked()
+void EmmaClientWidget::onBtExportStartTxtClicked()
 {
 	EmmaClient *svc = service();
 	if(svc) {
 		saveSettings();
-		svc->exportStartList();
+		svc->exportStartListRacomTxt();
 	}
 }
 
-void EmmaClientWidget::onBtExportXML30Clicked()
+void EmmaClientWidget::onBtExportResultsXML30Clicked()
 {
 	EmmaClient *svc = service();
 	if(svc) {

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.cpp
@@ -26,7 +26,8 @@ EmmaClientWidget::EmmaClientWidget(QWidget *parent)
 		ui->edExportInterval->setValue(ss.exportIntervalSec());
 		ui->chExportStart->setCheckState((ss.exportStart()) ? Qt::Checked : Qt::Unchecked);
 		ui->chExportFinish->setCheckState((ss.exportFinish()) ? Qt::Checked : Qt::Unchecked);
-		ui->chExportXML30->setCheckState((ss.exportTypeXML3()) ? Qt::Checked : Qt::Unchecked);
+		ui->chExportStartXML30->setCheckState((ss.exportStartTypeXML3()) ? Qt::Checked : Qt::Unchecked);
+		ui->chExportXML30->setCheckState((ss.exportResultTypeXML3()) ? Qt::Checked : Qt::Unchecked);
 	}
 
 	connect(ui->btChooseExportDir, &QPushButton::clicked, this, &EmmaClientWidget::onBtChooseExportDirClicked);
@@ -34,6 +35,7 @@ EmmaClientWidget::EmmaClientWidget(QWidget *parent)
 	connect(ui->btExportFinish, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportFinishClicked);
 	connect(ui->btExportStart, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportStartClicked);
 	connect(ui->btExportXML30, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportXML30Clicked);
+	connect(ui->btExportStartXML30, &QPushButton::clicked, this, &EmmaClientWidget::onBtExportStartXML30Clicked);
 }
 
 EmmaClientWidget::~EmmaClientWidget()
@@ -90,7 +92,8 @@ bool EmmaClientWidget::saveSettings()
 		ss.setFileName(ui->edFileName->text().trimmed());
 		ss.setExportStart(ui->chExportStart->isChecked());
 		ss.setExportFinish(ui->chExportFinish->isChecked());
-		ss.setExportTypeXML3(ui->chExportXML30->isChecked());;
+		ss.setExportStartTypeXML3(ui->chExportStartXML30->isChecked());;
+		ss.setExportResultTypeXML3(ui->chExportXML30->isChecked());;
 		svc->setSettings(ss);
 		if(!dir.isEmpty()) {
 			if(!QDir().mkpath(dir))
@@ -127,5 +130,13 @@ void EmmaClientWidget::onBtExportXML30Clicked()
 	}
 }
 
+void EmmaClientWidget::onBtExportStartXML30Clicked()
+{
+	EmmaClient *svc = service();
+	if(svc) {
+		saveSettings();
+		svc->exportStartListIofXml3();
+	}
+}
 }}
 

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.h
@@ -21,10 +21,10 @@ public:
 	~EmmaClientWidget();
 private:
 	void onBtChooseExportDirClicked();
-	void onBtExportSplitsClicked();
-	void onBtExportFinishClicked();
-	void onBtExportStartClicked();
-	void onBtExportXML30Clicked();
+	void onBtExportSplitsTxtClicked();
+	void onBtExportFinishTxtClicked();
+	void onBtExportStartTxtClicked();
+	void onBtExportResultsXML30Clicked();
 	void onBtExportStartXML30Clicked();
 	bool acceptDialogDone(int result) override;
 	EmmaClient* service();

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.h
@@ -25,6 +25,7 @@ private:
 	void onBtExportFinishClicked();
 	void onBtExportStartClicked();
 	void onBtExportXML30Clicked();
+	void onBtExportStartXML30Clicked();
 	bool acceptDialogDone(int result) override;
 	EmmaClient* service();
 	bool saveSettings();

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.h
@@ -23,9 +23,9 @@ private:
 	void onBtChooseExportDirClicked();
 	void onBtExportSplitsTxtClicked();
 	void onBtExportFinishTxtClicked();
-	void onBtExportStartTxtClicked();
-	void onBtExportResultsXML30Clicked();
-	void onBtExportStartXML30Clicked();
+	void onBtExportStartListTxtClicked();
+	void onBtExportResultsXml30Clicked();
+	void onBtExportStartListXml30Clicked();
 	bool acceptDialogDone(int result) override;
 	EmmaClient* service();
 	bool saveSettings();

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.ui
@@ -69,9 +69,16 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
+       <widget class="QCheckBox" name="chExportStartXML30">
+        <property name="text">
+         <string>Enable export IOF XML 3.0 start list file</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="chExportXML30">
         <property name="text">
-         <string>Enable export IOF XML 3.0 file</string>
+         <string>Enable export IOF XML 3.0 result file</string>
         </property>
        </widget>
       </item>
@@ -91,9 +98,16 @@
          </spacer>
         </item>
         <item>
+         <widget class="QPushButton" name="btExportStartXML30">
+          <property name="text">
+           <string>Export start list</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QPushButton" name="btExportXML30">
           <property name="text">
-           <string>Export IOF XML 3.0</string>
+           <string>Export results</string>
           </property>
          </widget>
         </item>
@@ -192,7 +206,9 @@
   <tabstop>edExportDir</tabstop>
   <tabstop>btChooseExportDir</tabstop>
   <tabstop>edExportInterval</tabstop>
+  <tabstop>chExportStartXML30</tabstop>
   <tabstop>chExportXML30</tabstop>
+  <tabstop>btExportStartXML30</tabstop>
   <tabstop>btExportXML30</tabstop>
   <tabstop>edFileName</tabstop>
   <tabstop>chExportStart</tabstop>

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.ui
@@ -61,12 +61,12 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QLineEdit" name="edFileName"/>
+      <widget class="QLineEdit" name="edFileNameBase"/>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>File name prefix</string>
+        <string>File name base</string>
        </property>
       </widget>
      </item>
@@ -79,14 +79,14 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="QCheckBox" name="chExportStartXML30">
+       <widget class="QCheckBox" name="chExportStartListXml30">
         <property name="text">
          <string>Enable export start list</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="chExportResultsXML30">
+       <widget class="QCheckBox" name="chExportResultsXml30">
         <property name="text">
          <string>Enable export results</string>
         </property>
@@ -108,14 +108,14 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="btExportStartXML30">
+         <widget class="QPushButton" name="btExportStartListXml30">
           <property name="text">
            <string>Export start list</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="btExportResultsXML30">
+         <widget class="QPushButton" name="btExportResultsXml30">
           <property name="text">
            <string>Export results</string>
           </property>
@@ -133,7 +133,7 @@
      </property>
      <layout class="QFormLayout" name="formLayout_2">
       <item row="2" column="1">
-       <widget class="QCheckBox" name="chExportStartTxt">
+       <widget class="QCheckBox" name="chExportStartListTxt">
         <property name="text">
          <string>Enable export start list</string>
         </property>
@@ -169,7 +169,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="btExportStartTxt">
+         <widget class="QPushButton" name="btExportStartListTxt">
           <property name="text">
            <string>Export start list</string>
           </property>
@@ -206,15 +206,15 @@
   <tabstop>edExportDir</tabstop>
   <tabstop>btChooseExportDir</tabstop>
   <tabstop>edExportInterval</tabstop>
-  <tabstop>edFileName</tabstop>
-  <tabstop>chExportStartXML30</tabstop>
-  <tabstop>chExportResultsXML30</tabstop>
-  <tabstop>btExportStartXML30</tabstop>
-  <tabstop>btExportResultsXML30</tabstop>
-  <tabstop>chExportStartTxt</tabstop>
+  <tabstop>edFileNameBase</tabstop>
+  <tabstop>chExportStartListXml30</tabstop>
+  <tabstop>chExportResultsXml30</tabstop>
+  <tabstop>btExportStartListXml30</tabstop>
+  <tabstop>btExportResultsXml30</tabstop>
+  <tabstop>chExportStartListTxt</tabstop>
   <tabstop>chExportFinishTxt</tabstop>
   <tabstop>btExportSplitsTxt</tabstop>
-  <tabstop>btExportStartTxt</tabstop>
+  <tabstop>btExportStartListTxt</tabstop>
   <tabstop>btExportFinishTxt</tabstop>
  </tabstops>
  <resources/>

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclientwidget.ui
@@ -60,6 +60,16 @@
        </property>
       </widget>
      </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="edFileName"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>File name prefix</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -71,14 +81,14 @@
       <item>
        <widget class="QCheckBox" name="chExportStartXML30">
         <property name="text">
-         <string>Enable export IOF XML 3.0 start list file</string>
+         <string>Enable export start list</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="chExportXML30">
+       <widget class="QCheckBox" name="chExportResultsXML30">
         <property name="text">
-         <string>Enable export IOF XML 3.0 result file</string>
+         <string>Enable export results</string>
         </property>
        </widget>
       </item>
@@ -105,7 +115,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="btExportXML30">
+         <widget class="QPushButton" name="btExportResultsXML30">
           <property name="text">
            <string>Export results</string>
           </property>
@@ -119,30 +129,20 @@
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>RACOM</string>
+      <string>RACOM Text</string>
      </property>
      <layout class="QFormLayout" name="formLayout_2">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>File name prefix</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="edFileName"/>
-      </item>
       <item row="2" column="1">
-       <widget class="QCheckBox" name="chExportStart">
+       <widget class="QCheckBox" name="chExportStartTxt">
         <property name="text">
-         <string>Export start list</string>
+         <string>Enable export start list</string>
         </property>
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="QCheckBox" name="chExportFinish">
+       <widget class="QCheckBox" name="chExportFinishTxt">
         <property name="text">
-         <string>Export results</string>
+         <string>Enable export results</string>
         </property>
        </widget>
       </item>
@@ -162,23 +162,23 @@
          </spacer>
         </item>
         <item>
-         <widget class="QPushButton" name="btExportStart">
+         <widget class="QPushButton" name="btExportSplitsTxt">
+          <property name="text">
+           <string>Export radio codes</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="btExportStartTxt">
           <property name="text">
            <string>Export start list</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="btExportFinish">
+         <widget class="QPushButton" name="btExportFinishTxt">
           <property name="text">
            <string>Export results</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="btExportSplits">
-          <property name="text">
-           <string>Export radio codes</string>
           </property>
          </widget>
         </item>
@@ -206,16 +206,16 @@
   <tabstop>edExportDir</tabstop>
   <tabstop>btChooseExportDir</tabstop>
   <tabstop>edExportInterval</tabstop>
-  <tabstop>chExportStartXML30</tabstop>
-  <tabstop>chExportXML30</tabstop>
-  <tabstop>btExportStartXML30</tabstop>
-  <tabstop>btExportXML30</tabstop>
   <tabstop>edFileName</tabstop>
-  <tabstop>chExportStart</tabstop>
-  <tabstop>chExportFinish</tabstop>
-  <tabstop>btExportStart</tabstop>
-  <tabstop>btExportFinish</tabstop>
-  <tabstop>btExportSplits</tabstop>
+  <tabstop>chExportStartXML30</tabstop>
+  <tabstop>chExportResultsXML30</tabstop>
+  <tabstop>btExportStartXML30</tabstop>
+  <tabstop>btExportResultsXML30</tabstop>
+  <tabstop>chExportStartTxt</tabstop>
+  <tabstop>chExportFinishTxt</tabstop>
+  <tabstop>btExportSplitsTxt</tabstop>
+  <tabstop>btExportStartTxt</tabstop>
+  <tabstop>btExportFinishTxt</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/quickevent/app/quickevent/plugins/Relays/src/addlegdialogwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/addlegdialogwidget.cpp
@@ -57,9 +57,9 @@ AddLegDialogWidget::AddLegDialogWidget(QWidget *parent)
 	auto *reg_model = getPlugin<CompetitorsPlugin>()->registrationsModel();
 	ui->tblRegistrations->setTableModel(reg_model);
 	ui->tblRegistrations->setReadOnly(true);
-	regUpdateConnect = connect(reg_model, &qf::core::model::SqlTableModel::reloaded, [this]() {
-		ui->tblRegistrations->horizontalHeader()->resizeSections(QHeaderView::ResizeToContents);
-	});
+	connect(reg_model, &qf::core::model::SqlTableModel::reloaded, this, [this]() {
+			ui->tblRegistrations->horizontalHeader()->resizeSections(QHeaderView::ResizeToContents);
+		});
 
 	connect(ui->edFilter, &QLineEdit::textChanged, this, &AddLegDialogWidget::onFilterTextChanged);
 	connect(ui->tblCompetitors, &qf::qmlwidgets::TableView::doubleClicked, this, &AddLegDialogWidget::onCompetitorSelected);
@@ -69,7 +69,6 @@ AddLegDialogWidget::AddLegDialogWidget(QWidget *parent)
 
 AddLegDialogWidget::~AddLegDialogWidget()
 {
-	disconnect(regUpdateConnect);
 	delete ui;
 }
 

--- a/quickevent/app/quickevent/plugins/Relays/src/addlegdialogwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/addlegdialogwidget.cpp
@@ -43,11 +43,12 @@ AddLegDialogWidget::AddLegDialogWidget(QWidget *parent)
 			.select2("relays", "classId")
 			.select("COALESCE(relays.club, '') || ' ' || COALESCE(relays.name, '') AS relayName")
 			.select("COALESCE(lastName, '') || ' ' || COALESCE(firstName, '') AS competitorName")
-			.from("runs")
-			.join("runs.competitorId", "competitors.id")
+			.from("competitors")
+			.join("competitors.id", "runs.competitorId")
 			.join("runs.relayId", "relays.id")
 			.join("relays.classId", "classes.id")
 			.orderBy("competitorName");//.limit(10);
+//	qfInfo() << qb.toString();
 	competitors_model->setQueryBuilder(qb);
 	ui->tblCompetitors->setTableModel(competitors_model);
 	ui->tblCompetitors->setReadOnly(true);
@@ -74,7 +75,7 @@ void AddLegDialogWidget::onFilterTextChanged()
 {
 	QString txt = ui->edFilter->text().trimmed();
 	if(txt.length() < 3)
-		return;
+		txt.clear();	// clear filter when less than 3 chars (not return, need to clear filter)
 	ui->tblCompetitors->filterByString(txt);
 	ui->tblRegistrations->filterByString(txt);
 	ui->edFilter->setFocus();

--- a/quickevent/app/quickevent/plugins/Relays/src/addlegdialogwidget.h
+++ b/quickevent/app/quickevent/plugins/Relays/src/addlegdialogwidget.h
@@ -35,7 +35,6 @@ private:
 	Ui::AddLegDialogWidget *ui;
 	QTimer *m_updateStatusTimer = nullptr;
 	QString m_defaultStatusText;
-	QMetaObject::Connection regUpdateConnect;
 };
 
 #endif // ADDLEGDIALOGWIDGET_H

--- a/quickevent/app/quickevent/plugins/Relays/src/addlegdialogwidget.h
+++ b/quickevent/app/quickevent/plugins/Relays/src/addlegdialogwidget.h
@@ -26,6 +26,7 @@ private:
 	void onFilterTextChanged();
 	void onCompetitorSelected();
 	void onRegistrationSelected();
+	void onUnregistredRunnerAdded();
 
 	void updateLegAddedStatus(const QString &msg);
 
@@ -34,6 +35,7 @@ private:
 	Ui::AddLegDialogWidget *ui;
 	QTimer *m_updateStatusTimer = nullptr;
 	QString m_defaultStatusText;
+	QMetaObject::Connection regUpdateConnect;
 };
 
 #endif // ADDLEGDIALOGWIDGET_H

--- a/quickevent/app/quickevent/plugins/Relays/src/addlegdialogwidget.ui
+++ b/quickevent/app/quickevent/plugins/Relays/src/addlegdialogwidget.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0">
    <property name="spacing">
     <number>5</number>
    </property>
@@ -91,6 +91,97 @@
      </item>
     </layout>
    </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Unregistered runner</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>First name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="edLastName">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>4</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Last name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="edFirstName">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>4</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_6">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>SI</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QSpinBox" name="edSiId">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>2</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="maximum">
+         <number>99999999</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QPushButton" name="btUseUnregRunner">
+        <property name="text">
+         <string>Add to leg</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -100,6 +191,15 @@
    <header location="global">qf/qmlwidgets/tableview.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>edFilter</tabstop>
+  <tabstop>tblRegistrations</tabstop>
+  <tabstop>tblCompetitors</tabstop>
+  <tabstop>edFirstName</tabstop>
+  <tabstop>edLastName</tabstop>
+  <tabstop>edSiId</tabstop>
+  <tabstop>btUseUnregRunner</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -393,7 +393,7 @@ qf::core::utils::Table RunsPlugin::nstagesClassResultsTable(int stages_count, in
 {
 	qfs::QueryBuilder qb;
 	qb.select2("competitors", "id, registration, licence")
-			.select2("clubs","name")
+			.select2("clubs","name, abbr")
 			.select("COALESCE(competitors.lastName, '') || ' ' || COALESCE(competitors.firstName, '') AS competitorName")
 			.from("competitors")
 			.join("LEFT JOIN clubs ON substr(competitors.registration, 1, 3) = clubs.abbr")
@@ -584,7 +584,7 @@ qf::core::utils::TreeTable RunsPlugin::stageResultsTable(int stage_id, const QSt
 		qb.select2("competitors", "registration, lastName, firstName")
 			.select("COALESCE(competitors.lastName, '') || ' ' || COALESCE(competitors.firstName, '') AS competitorName")
 			.select2("runs", "*")
-			.select2("clubs", "name")
+			.select2("clubs", "name, abbr")
 			.from("competitors")
 			.join("LEFT JOIN clubs ON substr(competitors.registration, 1, 3) = clubs.abbr")
 			.joinRestricted("competitors.id"
@@ -864,6 +864,14 @@ bool RunsPlugin::exportResultsIofXml30Stage(int stage_id, const QString &file_na
 				 }
 			);
 
+			person_result.insert(person_result.count(),
+				QVariantList{"Organisation",
+					QVariantList{"ShortName",
+						tt2_row.value(QStringLiteral("clubs.abbr"))
+					}
+				}
+			);
+
 			QVariantList result{"Result"};
 			//int run_id = tt2_row.value(QStringLiteral("runs.id")).toInt();
 			int stime = tt2_row.value(QStringLiteral("startTimeMs")).toInt();
@@ -896,7 +904,7 @@ bool RunsPlugin::exportResultsIofXml30Stage(int stage_id, const QString &file_na
 			}
 			result.insert(result.count(), QVariantList{"Status", competitor_status});
 			int ix = stpTime_0_ix;
-			for(QVariant v : codes) {
+			for(QVariant &v : codes) {
 				quickevent::core::CodeDef cd(v.toMap());
 				int stp_time = tt2_row.value(ix).toInt();
 				QVariantList split_time{

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -904,7 +904,7 @@ bool RunsPlugin::exportResultsIofXml30Stage(int stage_id, const QString &file_na
 			}
 			result.insert(result.count(), QVariantList{"Status", competitor_status});
 			int ix = stpTime_0_ix;
-			for(QVariant &v : codes) {
+			for(const QVariant &v : codes) {
 				quickevent::core::CodeDef cd(v.toMap());
 				int stp_time = tt2_row.value(ix).toInt();
 				QVariantList split_time{

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -1079,7 +1079,9 @@ qf::core::utils::TreeTable RunsPlugin::startListClassesTable(const QString &wher
 	qb2.select2("competitors", "lastName, firstName, registration, startNumber")
 		.select("COALESCE(competitors.lastName, '') || ' ' || COALESCE(competitors.firstName, '') AS competitorName")
 		.select2("runs", "siId, startTimeMs")
+		.select2("clubs","name, abbr")
 		.from("competitors")
+		.join("LEFT JOIN clubs ON substr(competitors.registration, 1, 3) = clubs.abbr")
 		.joinRestricted("competitors.id", "runs.competitorId", "runs.stageId={{stage_id}} AND runs.isRunning", "INNER JOIN")
 		.where("competitors.classId={{class_id}}")
 		.orderBy("runs.startTimeMs, competitors.lastName");
@@ -2293,6 +2295,11 @@ bool RunsPlugin::exportStartListStageIofXml30(int stage_id, const QString &file_
 			append_list(xml_start, QVariantList{"ControlCard", tt2_row.value(QStringLiteral("runs.siId"))});
 			append_list(xml_person, person);
 			append_list(xml_person, xml_start);
+			append_list(xml_person, QVariantList{"Organisation",
+										QVariantList{"ShortName", tt2_row.value(QStringLiteral("clubs.abbr"))
+						}
+					}
+				);
 			append_list(class_start, xml_person);
 		}
 		append_list(xml_root, class_start);


### PR DESCRIPTION
* oprava generenovani radio kodu pro txt (racom) exportu pro EmmaClient, na postgresu to padalo, opraven SQL dotaz.
* pridani oddilu do XML exportu pro EmmaClient (startovka i vysledky)
* pridani exportu XML Startovky do služby pro EmmaClient 
* uprava UI sluzby a pouziti jmena souboru z UI pro vsechny exporty

Funkcnost buildu otestovana na oblzi PBM, 24.10.2021 ( plati pro prvni 2 commity )