### PR TITLE
Fix mass start time overwrite by readout of previous leg

### DIFF
--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
@@ -444,13 +444,12 @@ void CardReaderPlugin::assignCardToRun(int card_id, int run_id)
 	processCardToRunAssignment(card_id, run_id);
 }
 
-void CardReaderPlugin::setStartTimeForNextLeg(int relay_id, int prev_leg, int prev_finish_time) {
+void CardReaderPlugin::setStartTime(int relay_id, int leg, int start_time) {
 	qf::core::sql::Query q;
-	q.exec("UPDATE runs SET startTimeMs=" + QString::number(prev_finish_time)
+	q.execThrow("UPDATE runs SET startTimeMs=" + QString::number(start_time)
 		   + " WHERE relayId=" + QString::number(relay_id)
-		   + " AND leg=" + QString::number(prev_leg+1)
-		   + " AND COALESCE(startTimeMs, 0)=0"
-		   , qf::core::Exception::Throw);
+		   + " AND leg=" + QString::number(leg)
+		   + " AND COALESCE(startTimeMs, 0)=0");
 }
 
 bool CardReaderPlugin::processCardToRunAssignment(int card_id, int run_id)
@@ -475,7 +474,7 @@ bool CardReaderPlugin::processCardToRunAssignment(int card_id, int run_id)
 			if(q.next()) {
 				int prev_finish_time = q.value(0).toInt();
 				if(prev_finish_time > 0) {
-					setStartTimeForNextLeg(relay_id, leg-1, prev_finish_time);
+					setStartTime(relay_id, leg, prev_finish_time);
 				}
 			}
 		}

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
@@ -121,16 +121,9 @@ int CardReaderPlugin::findRunId(int si_id, int si_finish_time, QString *err_msg)
 		run_id = q.value("id").toInt();
 		int run_start = q.value("startTimeMs").toInt();
 		int run_finish = q.value("finishTimeMs").toInt();
-		if(is_relays) {
-			int run_leg = q.value("leg").toInt();
-			if(run_start == 0 && run_leg != 1) {
-				/// start time not set => this leg does not event start
-				qfInfo() << tr("skipping assign of SI: %1 to run_id: %2; start time not set, this leg does not event start").arg(si_id).arg(run_id);
-				continue;
-			}
-		}
 		if(si_finish_time == siut::SICard::INVALID_SI_TIME) {
 			/// No finnishTime given, cannot guess between runners with duplicate SI Card
+			/// used for radio punches
 			return run_id;
 		}
 		if(run_start > si_finish_time_msec) {

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp
@@ -498,9 +498,6 @@ bool CardReaderPlugin::processCardToRunAssignment(int card_id, int run_id)
 				processCardToRunAssignment(card_id, run_id);
 			}
 		}
-
-		/// set start time for next leg
-		setStartTimeForNextLeg(relay_id, leg, checked_card.finishTimeMs());
 	}
 	else {
 		quickevent::core::si::CheckedCard checked_card = checkCard(card_id, run_id);

--- a/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.h
+++ b/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.h
@@ -65,7 +65,7 @@ private:
 	void updateCardToRunAssignmentInPunches(int stage_id, int card_id, int run_id);
 	bool saveCardAssignedRunnerIdSql(int card_id, int run_id);
 	void updateCheckedCardValuesSql(const quickevent::core::si::CheckedCard &checked_card) noexcept(false);
-	void setStartTimeForNextLeg(int relay_id, int prev_leg, int prev_finish_time);
+	void setStartTime(int relay_id, int leg, int start_time);
 private:
 	QList<CardChecker*> m_cardCheckers;
 };

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,5 +1,4 @@
 #pragma once
 
-
 #define APP_VERSION "2.5.4"
 

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define APP_VERSION "2.4.7"
+#define APP_VERSION "2.4.8"
 


### PR DESCRIPTION
recently i added this line to set start times for next legs in advance
```cpp
		/// set start time for next leg
		setStartTimeForNextLeg(relay_id, leg, checked_card.finishTimeMs());
```
https://github.com/otahirs/quickbox/blob/dd567e5f6b358e4da30f0cffd529713d8f1c7045/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp#L502-L503

---
so this check could be implemented
```cpp
		if(is_relays) {
			int run_leg = q.value("leg").toInt();
			if(run_start == 0 && run_leg != 1) {
				/// start time not set => this leg does not event start
				qfInfo() << tr("skipping assign of SI: %1 to run_id: %2; start time not set, this leg does not event start").arg(si_id).arg(run_id);
				continue;
			}
		}
```
https://github.com/otahirs/quickbox/blob/dd567e5f6b358e4da30f0cffd529713d8f1c7045/quickevent/app/quickevent/plugins/CardReader/src/cardreaderplugin.cpp#L124-L131

---
however, setting start time for next legs in advance during readout is not desired if the start time is set manually for runners starting from a mass start, as they would be overwritten.

so to fix the unwanted overwrite of start times I propose deleting both snippets. 
ps: as a sideeffect to this fix, if the same SI Card is used during relays twice, manual assign is needed for both runners as it is impossible to guess if the second runner does the readout or if the first one is reading out again with changes for whatever reason