### PR TITLE
Fix #758 - Fix Windows build in Github Actions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -32,7 +32,7 @@ jobs:
         host: 'linux'
         
     - name: Get app version
-      run: | 
+      run: |
         echo "VERSION=`grep APP_VERSION quickevent/app/quickevent/src/appversion.h | cut -d\\" -f2`" >> $GITHUB_ENV
           
     - name: Get AppImageTool
@@ -59,7 +59,7 @@ jobs:
       
       
   build_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Dočasný fix - `windows-latest` se změnilo z `windows-2019` na `windows-2022` - bude potřeba důkladněji prozkoumat a zjistit příčinu problému (https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md).