### PR TITLE
Try to fix #758 - Fix Windows build in Github Actions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -59,7 +59,7 @@ jobs:
       
       
   build_windows:
-    runs-on: windows-2019
+    runs-on: windows-latest
     defaults:
       run:
         shell: bash
@@ -82,6 +82,9 @@ jobs:
           C:/msys64/mingw64/bin/liblzma-5.dll
           C:/msys64/mingw64/bin/zlib1.dll
           C:/msys64/mingw64/bin/libpq.dll
+          C:/msys64/mingw64/bin/libwinpthread-1.dll
+          C:/msys64/mingw64/bin/libgcc_s_seh-1.dll
+          C:/msys64/mingw64/bin/libstdc++-6.dll
         key: ${{ runner.os }}-Libraries
       
     - name: Get OpenSSL and PostgreSQL libraries


### PR DESCRIPTION
switch to windows-latest
libwinpthread-1.dll, libgcc_s_seh-1.dll, libstdc++-6.dll get from mingw directory
