### PR TITLE
Fix clang warning

### DIFF
--- a/libqf/libqfcore/src/core/logentrymap.cpp
+++ b/libqf/libqfcore/src/core/logentrymap.cpp
@@ -16,6 +16,8 @@ static const auto KEY_LINE = QStringLiteral("line");
 static const auto KEY_FUNCTION = QStringLiteral("function");
 static const auto KEY_TIME_STAMP = QStringLiteral("timestamp");
 
+LogEntryMap::~LogEntryMap() = default;
+
 LogEntryMap::LogEntryMap(NecroLog::Level level, const QString &category, const QString &message, const QString &file, int line, const QString &function)
 {
 	this->operator[](KEY_LEVEL) = (int)level;

--- a/libqf/libqfcore/src/core/logentrymap.h
+++ b/libqf/libqfcore/src/core/logentrymap.h
@@ -15,6 +15,7 @@ public:
 	LogEntryMap() : QVariantMap() {}
 	LogEntryMap(NecroLog::Level level, const QString &category, const QString &message, const QString &file = QString(), int line = -1, const QString &function = QString());
 	LogEntryMap(const QVariantMap &m) : QVariantMap(m) {}
+	virtual ~LogEntryMap();
 public:
 	NecroLog::Level level() const;
 	LogEntryMap& setLevel(NecroLog::Level l);


### PR DESCRIPTION
/usr/include/qt/QtCore/qmetatype.h:819:9: warning: destructor called on non-final 'qf::core::LogEntryMap' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
        static_cast<T*>(t)->~T();
        ^
/usr/include/qt/QtCore/qmetatype.h:1867:83: note: in instantiation of member function 'QtMetaTypePrivate::QMetaTypeFunctionHelper<qf::core::LogEntryMap, true>::Destruct' requested here
                                   QtMetaTypePrivate::QMetaTypeFunctionHelper<T>::Destruct,
                                                                                  ^
/usr/include/qt/QtCore/qmetatype.h:1896:12: note: in instantiation of function template specialization 'qRegisterNormalizedMetaType<qf::core::LogEntryMap>' requested here
    return qRegisterNormalizedMetaType<T>(normalizedTypeName, dummy, defined);
           ^
/home/vk/git/eyas/3rdparty/quickbox/libqf/libqfcore/include/qf/core/../../../src/core/logentrymap.h:41:1: note: in instantiation of function template specialization 'qRegisterMetaType<qf::core::LogEntryMap>' requested here
Q_DECLARE_METATYPE(qf::core::LogEntryMap)
^
/usr/include/qt/QtCore/qmetatype.h:2056:34: note: expanded from macro 'Q_DECLARE_METATYPE'
.#define Q_DECLARE_METATYPE(TYPE) Q_DECLARE_METATYPE_IMPL(TYPE)
                                 ^
/usr/include/qt/QtCore/qmetatype.h:2068:35: note: expanded from macro 'Q_DECLARE_METATYPE_IMPL'
                const int newId = qRegisterMetaType< TYPE >(#TYPE,      \
                                  ^
/usr/include/qt/QtCore/qmetatype.h:819:30: note: qualify call to silence this warning
        static_cast<T*>(t)->~T();