### PR TITLE
Extend SI punch decode - control code can be up to 511

### DIFF
--- a/libsiut/src/sipunch.cpp
+++ b/libsiut/src/sipunch.cpp
@@ -24,12 +24,14 @@ SIPunch::SIPunch(const QByteArray &card_data, int ix)
 	bit 3...1 - day of week, 000 = Sunday, 110 = Saturday
 	bit 5...4 - week counter 0…3, relative
 	bit 7...6 - control station code number high
-	(...1023) (reserved)
+	(...511)
 	punching time PTH, PTL - 12h binary
 	*/
 	setTime((uint16_t)getUnsigned(card_data, ix + 2, 2));
-	setCode((uint8_t)card_data[ix + 1]);
 	uint8_t pdt = (uint8_t)card_data[ix];
+	uint16_t code_complete = ((pdt & 0x60) >> 6) << 8;
+	code_complete += (uint8_t)card_data[ix + 1];
+	setCode(code_complete);
 	setPmFlag(pdt & 1);
 	setDayOfWeek((pdt & 0x0e) >> 1);
 	setWeekCnt((pdt & 0x30) >> 4);


### PR DESCRIPTION
Nahodne jsem zjistil ze dle SPORTident Config+ je nejvyssi mozne cislo kontroly 511. Umoznuje to zapsat do kontroly, nasledne do cipu. Zvladne to i vycist.
QE zatim zvladne kod pouze do cisla 255.
Co jsem zkousel jiny vycitaci SW (si_read) tak ten to spravne nacte uz v buildu z roku 2016.
Takze to vypada ze uz se toto dlouho nezmenilo.

Zkusil jsem udelat upravu ve funkci  SIPunch::SIPunch(const QByteArray &card_data, int ix);
Zkusebni vycteni fungovalo. Zkouseno na cipu v10 a SIAC.

![si_config_code_help](https://user-images.githubusercontent.com/8378685/182044643-85580830-092e-4453-aae6-f55bd4f21064.png)