### PR TITLE
qt6: Get rid of Core5Compat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if (NOT TARGET libnecrolog)
 endif()
 
 if(USE_QT6)
-    find_package(Qt6 REQUIRED COMPONENTS Core Widgets Gui Sql Qml Xml LinguistTools PrintSupport Svg SerialPort Multimedia Network Core5Compat)
+    find_package(Qt6 REQUIRED COMPONENTS Core Widgets Gui Sql Qml Xml LinguistTools PrintSupport Svg SerialPort Multimedia Network)
     set(Qt_FOUND ${Qt6_FOUND})
 else()
     find_package(Qt5 5.11 REQUIRED COMPONENTS Core Widgets Gui Sql Qml Xml LinguistTools PrintSupport Svg SerialPort Multimedia Network)

--- a/libqf/libqfcore/CMakeLists.txt
+++ b/libqf/libqfcore/CMakeLists.txt
@@ -35,9 +35,6 @@ add_library(libqfcore SHARED
     )
 
 target_link_libraries(libqfcore PUBLIC libnecrolog Qt::Core Qt::Sql PRIVATE Qt::Gui Qt::Qml Qt::Xml libnecrolog)
-if(USE_QT6)
-    target_link_libraries(libqfcore PUBLIC Qt::Core5Compat)
-endif()
 target_include_directories(libqfcore PUBLIC include)
 target_compile_definitions(libqfcore PRIVATE QFCORE_BUILD_DLL)
 

--- a/libqf/libqfcore/src/core/collator.cpp
+++ b/libqf/libqfcore/src/core/collator.cpp
@@ -2,7 +2,6 @@
 #include "log.h"
 
 #include <QString>
-#include <QStringRef>
 
 using namespace qf::core;
 /*
@@ -29,13 +28,6 @@ const Collator &Collator::sharedNull()
 }
 
 int Collator::compare(const QString &s1, const QString &s2) const
-{
-	QStringRef sr1(&s1);
-	QStringRef sr2(&s2);
-	return compare(sr1, sr2);
-}
-
-int Collator::compare(const QStringRef &s1, const QStringRef &s2) const
 {
 	int ret = 0;
 	for(int i=0; i<s1.length() && i<s2.length(); i++) {

--- a/libqf/libqfcore/src/core/collator.h
+++ b/libqf/libqfcore/src/core/collator.h
@@ -9,8 +9,6 @@
 #include <QLocale>
 #include <QSharedDataPointer>
 
-class QStringRef;
-
 namespace qf {
 namespace core {
 
@@ -43,7 +41,6 @@ public:
 	QF_SHARED_CLASS_FIELD_RW(QLocale::Language, l, setL, anguage)
 
 	int compare(const QString &s1, const QString &s2) const;
-	int compare(const QStringRef &s1, const QStringRef &s2) const;
 
 	static QByteArray toAscii7(QLocale::Language lang, const QString &s, bool to_lower);
 	static QChar removePunctuation(QLocale::Language language, QChar c);

--- a/libqf/libqfcore/src/core/utils.cpp
+++ b/libqf/libqfcore/src/core/utils.cpp
@@ -5,7 +5,6 @@
 #include <QSet>
 #include <QDate>
 #include <QRegularExpression>
-#include <QRegExp> // Get rid of this
 
 namespace qf {
 namespace core {
@@ -134,13 +133,12 @@ int Utils::findCaption(const QString &caption_format, int from_ix, QString *capt
 QSet<QString> Utils::findCaptions(const QString &caption_format)
 {
 	QSet<QString> ret;
-	QRegExp rx;
+	QRegularExpression rx;
 	rx.setPattern("\\{\\{([A-Za-z][A-Za-z0-9]*(\\.[A-Za-z][A-Za-z0-9]*)*)\\}\\}");
-	rx.setPatternSyntax(QRegExp::RegExp);
-	int ix = 0;
-	while((ix = rx.indexIn(caption_format, ix)) != -1) {
-		ret << rx.cap(1);
-		ix += rx.matchedLength();
+	auto match_iterator = rx.globalMatch(caption_format);
+	while (match_iterator.hasNext()) {
+		auto match = match_iterator.next();
+		ret << match.captured(1);
 	}
 	return ret;
 }

--- a/libqf/libqfcore/src/model/sqltablemodel.cpp
+++ b/libqf/libqfcore/src/model/sqltablemodel.cpp
@@ -6,7 +6,6 @@
 #include "../sql/dbenum.h"
 #include "../sql/dbenumcache.h"
 
-#include <QRegExp>
 #include <QSqlError>
 #include <QSqlRecord>
 #include <QSqlIndex>

--- a/libqf/libqfcore/src/utils/table.cpp
+++ b/libqf/libqfcore/src/utils/table.cpp
@@ -7,7 +7,6 @@
 #include "../core/utils.h"
 #include "../core/string.h"
 
-#include <QTextCodec>
 #include <QStringBuilder>
 #include <QDate>
 #include <QDomElement>

--- a/libqf/libqfqmlwidgets/src/dialogs/previewdialog.cpp
+++ b/libqf/libqfqmlwidgets/src/dialogs/previewdialog.cpp
@@ -8,7 +8,6 @@
 #include <QFile>
 #include <QUrl>
 #include <QTextEdit>
-#include <QTextCodec>
 #include <QTextStream>
 
 using namespace qf::qmlwidgets::dialogs;

--- a/libqf/libqfqmlwidgets/src/exporttableviewwidget.cpp
+++ b/libqf/libqfqmlwidgets/src/exporttableviewwidget.cpp
@@ -5,7 +5,6 @@
 #include <qf/core/utils/table.h>
 
 #include <QMenu>
-#include <QTextCodec>
 
 namespace qf {
 namespace qmlwidgets {
@@ -17,8 +16,7 @@ ExportTableViewWidget::ExportTableViewWidget(QTableView *table_view, QWidget *pa
 {
 	ui->setupUi(this);
 
-	foreach(QByteArray ba, QTextCodec::availableCodecs())
-		ui->lstCodec->addItem(ba);
+	ui->lstCodec->addItem("UTF-8");
 	ui->lstCodec->setCurrentText(QStringLiteral("UTF-8"));
 
 	ui->tableView->setEditTriggers(QAbstractItemView::NoEditTriggers);

--- a/libqf/libqfqmlwidgets/src/reports/processor/reportitem_html.cpp
+++ b/libqf/libqfqmlwidgets/src/reports/processor/reportitem_html.cpp
@@ -149,9 +149,9 @@ ReportItem::PrintResult ReportItemPara::printHtml(HTMLElement & out)
 	QDomElement el_div = out.ownerDocument().createElement("div");
 	QDomElement el_p = out.ownerDocument().createElement("p");
 	QString text = paraText();
-	QRegExp rx = ReportItemMetaPaint::checkReportSubstitutionRegExp;
-	if(rx.exactMatch(text)) {
-		bool check_on = rx.capturedTexts().value(1) == "1";
+	QRegularExpression rx = ReportItemMetaPaint::checkReportSubstitutionRegExp;
+	if(auto match = rx.match(text); match.hasMatch()) {
+		bool check_on = match.capturedTexts().value(1) == "1";
 		text = (check_on)? "X": QString();
 	}
 	setElementText(el_p, text);

--- a/libqf/libqfqmlwidgets/src/reports/processor/reportitempara.cpp
+++ b/libqf/libqfqmlwidgets/src/reports/processor/reportitempara.cpp
@@ -76,8 +76,8 @@ ReportItem::PrintResult ReportItemPara::printMetaPaintChildren(ReportItemMetaPai
 		device_bounding_rect = qmlwidgets::graphics::mm2device(bounding_rect, processor()->paintDevice());
 
 		bool render_check_mark = false;
-		QRegExp rx = ReportItemMetaPaint::checkReportSubstitutionRegExp;
-		if(rx.exactMatch(text_to_layout)) {
+		QRegularExpression rx = ReportItemMetaPaint::checkReportSubstitutionRegExp;
+		if(auto match = rx.match(text_to_layout); match.hasMatch()) {
 			//bool check_on = rx.capturedTexts().value(1) == "1";
 			device_bounding_rect = font_metrics.boundingRect('X');
 			render_check_mark = true;

--- a/libqf/libqfqmlwidgets/src/reports/processor/reportpainter.cpp
+++ b/libqf/libqfqmlwidgets/src/reports/processor/reportpainter.cpp
@@ -26,7 +26,7 @@ using namespace qf::qmlwidgets::reports;
 const QString ReportItemMetaPaint::pageCountReportSubstitution = "@{n}";
 //const QString ReportItemMetaPaint::checkOnReportSubstitution = "@{check:1}";
 const QString ReportItemMetaPaint::checkReportSubstitution = "@{check:${STATE}}";
-const QRegExp ReportItemMetaPaint::checkReportSubstitutionRegExp = QRegExp("@\\{check:(\\d)\\}");
+const QRegularExpression ReportItemMetaPaint::checkReportSubstitutionRegExp = QRegularExpression(QRegularExpression::anchoredPattern("@\\{check:(\\d)\\}"));
 
 ReportItemMetaPaint::ReportItemMetaPaint()
 	: Super(nullptr)
@@ -643,9 +643,9 @@ void ReportItemMetaPaintCheck::paint(ReportPainter * painter, unsigned mode)
 	QFontMetricsF font_metrics = QFontMetricsF(painter->font(), painter->device());
 
 	//qfInfo() << "paint" << text;
-	QRegExp rx = ReportItemMetaPaint::checkReportSubstitutionRegExp;
-	if(rx.exactMatch(text)) {
-		bool check_on = rx.capturedTexts().value(1) == "1";
+	QRegularExpression rx = ReportItemMetaPaint::checkReportSubstitutionRegExp;
+	if(auto match = rx.match(text); match.hasMatch()) {
+		bool check_on = match.capturedTexts().value(1) == "1";
 		/// V tabulkach by jako check OFF slo netisknout vubec nic,
 		/// ale na ostatnich mistech repotu je to zavadejici .
 

--- a/libqf/libqfqmlwidgets/src/reports/processor/reportpainter.h
+++ b/libqf/libqfqmlwidgets/src/reports/processor/reportpainter.h
@@ -19,7 +19,6 @@
 #include <QObject>
 #include <QPainter>
 #include <QPrinter>
-#include <QRegExp>
 
 namespace qf {
 namespace qmlwidgets {
@@ -41,7 +40,7 @@ public:
 	enum PaintMode {PaintBorder=1, PaintFill=2, PaintAll=3};
 	//! string v reportu, ktery se vymeni za celkovy pocet stranek v reportu.
 	static const QString pageCountReportSubstitution;
-	static const QRegExp checkReportSubstitutionRegExp;
+	static const QRegularExpression checkReportSubstitutionRegExp;
 	static const QString checkReportSubstitution;
 	//static const QString checkOffReportSubstitution;
 	typedef qf::qmlwidgets::graphics::Rect Rect;

--- a/libqf/libqfqmlwidgets/src/tableview.cpp
+++ b/libqf/libqfqmlwidgets/src/tableview.cpp
@@ -41,7 +41,6 @@
 #include <QInputDialog>
 #include <QFileDialog>
 #include <QPainter>
-#include <QStringRef>
 #include <QToolButton>
 #include <QTextStream>
 //#define QF_TIMESCOPE_ENABLED
@@ -1287,11 +1286,10 @@ void TableView::seek(const QString &prefix_str)
 			QString data_str = model()->data(ix, Qt::DisplayRole).toString();//.mid(0, prefix_str.length()).toLower();
 			/// QTBUG-37689 QCollator allways sorts case sensitive
 			/// workarounded by own implementation of qf::core::Collator
-			QStringRef ps(&prefix_str);
-			QStringRef ds(&data_str, 0, qMin(prefix_str.length(), data_str.length()));
+			QString ds = data_str.left(qMin(prefix_str.length(), data_str.length()));
 			//QString ps = prefix_str.toLower();
 			//QString ds = data_str.mid(0, ps.length()).toLower();
-			int cmp = sort_collator.compare(ps, ds);
+			int cmp = sort_collator.compare(prefix_str, ds);
 			//qfInfo() << ps << "cmp" << ds << "->" << cmp;
 			if(cmp <= 0) {
 				setCurrentIndex(ix);

--- a/libqf/libqfqmlwidgets/src/tableviewproxymodel.cpp
+++ b/libqf/libqfqmlwidgets/src/tableviewproxymodel.cpp
@@ -5,7 +5,6 @@
 #include <qf/core/model/tablemodel.h>
 
 #include <QColor>
-#include <QTextCodec>
 #include <QDateTime>
 
 //namespace qfm = qf::core::model;

--- a/libqf/libqfqmlwidgets/src/texteditwidget.cpp
+++ b/libqf/libqfqmlwidgets/src/texteditwidget.cpp
@@ -13,7 +13,6 @@
 
 #include <QPrintDialog>
 #include <QPrinter>
-#include <QTextCodec>
 #include <QStyle>
 #include <QTextStream>
 

--- a/tools/qsqlmon/src/dlgeditconnection.cpp
+++ b/tools/qsqlmon/src/dlgeditconnection.cpp
@@ -6,7 +6,6 @@
 
 #include <QFileDialog>
 #include <QVariant>
-#include <QTextCodec>
 
 //#define QF_NO_TRASH_OUTPUT
 	


### PR DESCRIPTION
I'm not sure if I did the regexes wrong. It seems that "anchoredPattern"
is correct, because the regex was allways used with "exactMatch". I'm
not sure however about "match" and "globalMatch". In findCaptions it was
obvious (I think), but the other usages I'm not sure.