### PR TITLE
feat(OResults): send runner data after readout or edit

### DIFF
--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
@@ -173,7 +173,7 @@ void OResultsClient::sendCompetitorChange(QString xml) {
 	connect(reply, &QNetworkReply::finished, reply, [reply]()
 	{
 		if(reply->error()) {
-			qfError() << "OReuslts.eu [competitor changed]:" << reply->errorString();
+			qfError() << "OReuslts.eu [competitor change]:" << reply->errorString();
 		}
 		else {
 			QString msg = reply->readAll();

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
@@ -9,6 +9,9 @@
 #include <qf/core/log.h>
 #include <plugins/Runs/src/runsplugin.h>
 #include <plugins/Relays/src/relaysplugin.h>
+#include <quickevent/core/si/checkedcard.h>
+#include <qf/core/utils/htmlutils.h>
+#include <qf/core/sql/query.h>
 
 #include <QDir>
 #include <QFile>
@@ -19,6 +22,7 @@
 #include <QStandardPaths>
 #include <QTextStream>
 #include <QTimer>
+#include <regex>
 
 namespace qfc = qf::core;
 namespace qfw = qf::qmlwidgets;
@@ -39,7 +43,7 @@ OResultsClient::OResultsClient(QObject *parent)
 	m_exportTimer = new QTimer(this);
 	connect(m_exportTimer, &QTimer::timeout, this, &OResultsClient::onExportTimerTimeOut);
 	connect(this, &OResultsClient::settingsChanged, this, &OResultsClient::init, Qt::QueuedConnection);
-
+	connect(getPlugin<EventPlugin>(), &Event::EventPlugin::dbEventNotify, this, &OResultsClient::onDbEventNotify, Qt::QueuedConnection);
 }
 
 QString OResultsClient::serviceName()
@@ -141,6 +145,175 @@ void OResultsClient::sendFile(QString name, QString request_path, QString file) 
 		}
 		reply->deleteLater();
 	});
+}
+
+void OResultsClient::onDbEventNotify(const QString &domain, int connection_id, const QVariant &data)
+{
+	if (status() != Status::Running)
+		return;
+	Q_UNUSED(connection_id)
+	if(domain == QLatin1String(Event::EventPlugin::DBEVENT_CARD_PROCESSED_AND_ASSIGNED)) {
+		auto checked_card = quickevent::core::si::CheckedCard(data.toMap());
+		int competitor_id = getPlugin<RunsPlugin>()->competitorForRun(checked_card.runId());
+		onCompetitorChanged(competitor_id);
+	}
+	if(domain == QLatin1String(Event::EventPlugin::DBEVENT_COMPETITOR_EDITED)) {
+		int competitor_id = data.toInt();
+		onCompetitorChanged(competitor_id);
+	}
+}
+
+void OResultsClient::sendCompetitorChange(QString xml) {
+	QUrl url(API_URL + "/meos");
+	QNetworkRequest request(url);
+	request.setRawHeader("pwd", settings().apiKey().toUtf8());
+	request.setHeader( QNetworkRequest::ContentTypeHeader, "application/xml" );
+	QNetworkReply *reply = m_networkManager->post(request, xml.toUtf8());
+
+	connect(reply, &QNetworkReply::finished, reply, [reply]()
+	{
+		if(reply->error()) {
+			qfError() << "OReuslts.eu [competitor changed]:" << reply->errorString();
+		}
+		else {
+			QString msg = reply->readAll();
+			if (msg.contains("BADPWD"))
+				qfError() << "OReuslts.eu [competitor change]: Invalid API key";
+			else if (!msg.contains("OK"))
+				qfError() << "OReuslts.eu [competitor change]: Failed to process request";
+		}
+		reply->deleteLater();
+	});
+}
+
+static void append_list(QVariantList &lst, const QVariantList &new_lst)
+{
+	lst.insert(lst.count(), new_lst);
+}
+
+static bool is_csos_reg(QString &reg)
+{
+	const std::regex csos_registration_regex("[A-Z]{3}[0-9]{4}");
+	return reg.length() == 7 && std::regex_match(reg.toStdString(), csos_registration_regex);
+}
+
+static int mop_start(int runner_start_ms) {
+	int stage_id = getPlugin<RunsPlugin>()->selectedStageId();
+	QDateTime event_start = getPlugin<EventPlugin>()->stageStartDateTime(stage_id);
+	QDateTime runner_start = event_start.addMSecs(runner_start_ms);
+	return event_start.date().startOfDay().msecsTo(runner_start) / 100;
+}
+
+static int mop_run_status_code(
+		int time,
+		bool isDisq,
+		bool isDisqByOrganizer,
+		bool isMissPunch,
+		bool isBadCheck,
+		bool isDidNotStart,
+		bool isDidNotFinish,
+		bool isNotCompeting)
+{
+	if (isNotCompeting)
+		return 99; // NP (Not participating)
+	if (isMissPunch)
+		return 3; //MP (Missing punch)
+	if (isDidNotFinish)
+		return 4; // DNF (Did not finish)
+	if (isDidNotStart)
+		return 20; // DNS (Did not start)
+	if (isBadCheck || isDisqByOrganizer || isDisq)
+		return 5; // DQ (Disqualified)
+	if (time)
+		return 1; // OK
+	return 0; // Unknown
+}
+
+
+void OResultsClient::onCompetitorChanged(int competitor_id)
+{
+	if (competitor_id == 0)
+		return;
+
+	int stage_id = getPlugin<RunsPlugin>()->selectedStageId();
+	qf::core::sql::Query q;
+	q.exec("SELECT competitors.registration, "
+		   "competitors.startNumber, "
+		   "competitors.lastName || ' ' || competitors.firstName AS name, "
+		   "classes.name AS class, "
+		   "runs.siId, "
+		   "runs.disqualified, "
+		   "runs.disqualifiedByOrganizer, "
+		   "runs.misPunch, "
+		   "runs.badCheck, "
+		   "runs.notStart, "
+		   "runs.notFinish, "
+		   "runs.notCompeting, "
+		   "runs.startTimeMs, "
+		   "runs.timeMs "
+		   "FROM runs "
+		   "INNER JOIN competitors ON competitors.id = runs.competitorId "
+		   "LEFT JOIN relays ON relays.id = runs.relayId  "
+		   "INNER JOIN classes ON classes.id = competitors.classId OR classes.id = relays.classId  "
+		   "WHERE competitors.id=" QF_IARG(competitor_id) " AND runs.stageId=" QF_IARG(stage_id), qf::core::Exception::Throw);
+	if(q.next()) {
+		QString registration = q.value(0).toString();
+		int start_num = q.value(1).toInt();
+		QString name = q.value(2).toString();
+		QString class_name = q.value(3).toString();
+		int card_num = q.value(4).toInt();
+		bool isDisq = q.value(5).toBool();
+		bool isDisqByOrganizer = q.value(6).toBool();
+		bool isMissPunch = q.value(7).toBool();
+		bool isBadCheck = q.value(8).toBool();
+		bool isDidNotStart = q.value(9).toBool();
+		bool isDidNotFinish = q.value(10).toBool();
+		bool isNotCompeting = q.value(11).toBool();
+		int start_time = q.value(12).toInt();
+		int running_time = q.value(13).toInt();
+
+		QString runner_id = is_csos_reg(registration) ? registration : QString::number(card_num);
+		int status_code = mop_run_status_code(running_time, isDisq, isDisqByOrganizer, isMissPunch, isBadCheck, isDidNotStart, isDidNotFinish, isNotCompeting);
+
+		if (runner_id.isEmpty() || card_num == 0)
+			return;
+
+		QVariantMap competitor {
+			{"stat", status_code}
+		};
+		if (start_num != 0)
+			competitor.insert("bib", start_num);
+		if (!class_name.isEmpty())
+			competitor.insert("cls", class_name);
+		if(start_time != 0)
+			competitor.insert("st", mop_start(start_time));
+		if(running_time != 0)
+			competitor.insert("rt", running_time / 100);
+
+
+		QVariantList xml_root{"MOPDiff",
+			QVariantMap {
+				{"xmlns", "http://www.melin.nu/mop"},
+				{"creator", "QuickEvent"},
+				{"createTime", QDateTime::currentDateTimeUtc().toString(Qt::ISODate)}
+			}
+		};
+		QVariantList xml_competitor{"cmp",
+			QVariantMap {
+				{"id", runner_id },
+				{"card", card_num },
+			},
+			QVariantList {"base",
+				competitor,
+				name
+			}
+		};
+		append_list(xml_root, xml_competitor);
+		qf::core::utils::HtmlUtils::FromXmlListOptions opts;
+		opts.setDocumentTitle("Competitor change");
+		auto xml_paylaod = qf::core::utils::HtmlUtils::fromXmlList(xml_root, opts);
+		sendCompetitorChange(xml_paylaod);
+	}
 }
 
 }}

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
@@ -193,7 +193,7 @@ static void append_list(QVariantList &lst, const QVariantList &new_lst)
 
 static bool is_csos_reg(QString &reg)
 {
-	const std::regex csos_registration_regex("[A-Z]{3}[0-9]{4}");
+	const static std::regex csos_registration_regex("[A-Z]{3}[0-9]{4}");
 	return reg.length() == 7 && std::regex_match(reg.toStdString(), csos_registration_regex);
 }
 
@@ -257,20 +257,20 @@ void OResultsClient::onCompetitorChanged(int competitor_id)
 		   "INNER JOIN classes ON classes.id = competitors.classId OR classes.id = relays.classId  "
 		   "WHERE competitors.id=" QF_IARG(competitor_id) " AND runs.stageId=" QF_IARG(stage_id), qf::core::Exception::Throw);
 	if(q.next()) {
-		QString registration = q.value(0).toString();
-		int start_num = q.value(1).toInt();
-		QString name = q.value(2).toString();
-		QString class_name = q.value(3).toString();
-		int card_num = q.value(4).toInt();
-		bool isDisq = q.value(5).toBool();
-		bool isDisqByOrganizer = q.value(6).toBool();
-		bool isMissPunch = q.value(7).toBool();
-		bool isBadCheck = q.value(8).toBool();
-		bool isDidNotStart = q.value(9).toBool();
-		bool isDidNotFinish = q.value(10).toBool();
-		bool isNotCompeting = q.value(11).toBool();
-		int start_time = q.value(12).toInt();
-		int running_time = q.value(13).toInt();
+		QString registration = q.value("registration").toString();
+		int start_num = q.value("startNumber").toInt();
+		QString name = q.value("name").toString();
+		QString class_name = q.value("class").toString();
+		int card_num = q.value("siId").toInt();
+		bool isDisq = q.value("disqualified").toBool();
+		bool isDisqByOrganizer = q.value("disqualifiedByOrganizer").toBool();
+		bool isMissPunch = q.value("misPunch").toBool();
+		bool isBadCheck = q.value("badCheck").toBool();
+		bool isDidNotStart = q.value("notStart").toBool();
+		bool isDidNotFinish = q.value("notFinish").toBool();
+		bool isNotCompeting = q.value("notCompeting").toBool();
+		int start_time = q.value("startTimeMs").toInt();
+		int running_time = q.value("timeMs").toInt();
 
 		QString runner_id = is_csos_reg(registration) ? registration : QString::number(card_num);
 		int status_code = mop_run_status_code(running_time, isDisq, isDisqByOrganizer, isMissPunch, isBadCheck, isDidNotStart, isDidNotFinish, isNotCompeting);

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
@@ -16,7 +16,7 @@ class OResultsClientSettings : public ServiceSettings
 	using Super = ServiceSettings;
 
 	QF_VARIANTMAP_FIELD(QString, a, setA, piKey)
-	QF_VARIANTMAP_FIELD2(int, e, setE, xportIntervalSec, 15)
+	QF_VARIANTMAP_FIELD2(int, e, setE, xportIntervalSec, 60)
 public:
 	OResultsClientSettings(const QVariantMap &o = QVariantMap()) : Super(o) {}
 };
@@ -38,14 +38,19 @@ public:
 	void exportResultsIofXml3();
 	void exportStartListIofXml3();
 	void loadSettings() override;
+	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
+
+private:
+	QTimer *m_exportTimer = nullptr;
+	QNetworkAccessManager *m_networkManager = nullptr;
+	const QString API_URL = "https://api.oresults.eu";
 private:
 	qf::qmlwidgets::framework::DialogWidget *createDetailWidget() override;
 	void onExportTimerTimeOut();
 	void init();
-	QTimer *m_exportTimer = nullptr;
-	QNetworkAccessManager *m_networkManager = nullptr;
 	void sendFile(QString name, QString request_path, QString file);
-	const QString API_URL = "https://api.oresults.eu";
+	void sendCompetitorChange(QString xml);
+	void onCompetitorChanged(int competitor_id);
 };
 
 }}

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclientwidget.ui
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclientwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>287</width>
+    <width>298</width>
     <height>240</height>
    </rect>
   </property>
@@ -32,16 +32,16 @@
         <string> sec</string>
        </property>
        <property name="minimum">
-        <number>5</number>
+        <number>10</number>
        </property>
        <property name="maximum">
         <number>600</number>
        </property>
        <property name="singleStep">
-        <number>5</number>
+        <number>10</number>
        </property>
        <property name="value">
-        <number>15</number>
+        <number>60</number>
        </property>
       </widget>
      </item>
@@ -66,8 +66,8 @@
       <item>
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Results are exported at given interval and usually includes all neccesarry data. 
-Nonetheless, both Results and Start list can be exported manualy using the buttons bellow.
+         <string>Results are exported at given interval.
+Both Results and Start list can be exported manualy using the buttons bellow. In addition, if the service is running, individual competitor data is send after reaout and after saving competitor dialog. 
 In case of unexpected errors, contact support@oresults.eu </string>
         </property>
         <property name="wordWrap">

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -389,6 +389,27 @@ int RunsPlugin::cardForRun(int run_id)
 	return card_id;
 }
 
+int RunsPlugin::competitorForRun(int run_id)
+{
+	qfLogFuncFrame() << "run id:" << run_id;
+	//QF_TIME_SCOPE("reloadTimesFromCard()");
+	if(!run_id)
+		return 0;
+	int competitor_id = 0;
+	{
+		qf::core::sql::Query q;
+		if(q.exec("SELECT competitorId FROM runs WHERE id=" QF_IARG(run_id))) {
+			if(q.next()) {
+				competitor_id = q.value(0).toInt();
+			}
+			else {
+				qfWarning() << "Cannot find card record for run id:" << run_id;
+			}
+		}
+	}
+	return competitor_id;
+}
+
 qf::core::utils::Table RunsPlugin::nstagesClassResultsTable(int stages_count, int class_id, int places, bool exclude_disq)
 {
 	qfs::QueryBuilder qb;

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.h
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.h
@@ -110,6 +110,7 @@ public:
 	void export_resultsHtmlNStages();
 	QString startListStageIofXml30(int stage_id);
 	QString resultsIofXml30Stage(int stage_id);
+	int competitorForRun(int run_id);
 private:
 	Q_SLOT void onInstalled();
 


### PR DESCRIPTION
push competitor data (including result status  - `OK, MissPunch,...`) to OResults.eu service immediately after  
readout (`DBEVENT_CARD_PROCESSED_AND_ASSIGNED`) and after competitor is saved (`DBEVENT_COMPETITOR_EDITED`) 

as most of the time sensitive data is handled by this feature, the default export interval is prolonged to 1min 