### PR TITLE
fix: compatibility with older linux systems

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build_linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
AppImage bundles built with ubuntu-latest (ubuntu-22.04) requires version of libc library that is not available on older systems. -> build the app on older ubuntu version to ensure compatibility