### PR TITLE
fix: windows build ssl version

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -77,8 +77,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          C:/msys64/mingw64/bin/libcrypto-1_1-x64.dll
-          C:/msys64/mingw64/bin/libssl-1_1-x64.dll
+          C:/msys64/mingw64/bin/libcrypto-3-x64.dll
+          C:/msys64/mingw64/bin/libssl-3-x64.dll
           C:/msys64/mingw64/bin/libiconv-2.dll
           C:/msys64/mingw64/bin/libintl-8.dll
           C:/msys64/mingw64/bin/libxml2-2.dll

--- a/quickevent/quickevent.iss
+++ b/quickevent/quickevent.iss
@@ -59,8 +59,8 @@ Source: {#SRC_DIR}\quickevent\app\quickevent\datafiles\*; DestDir: {app}\quickev
 
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
-Source: {#SSL_DIR}\bin\libcrypto-1_1-x64.dll; DestDir: {app}; Flags: ignoreversion
-Source: {#SSL_DIR}\bin\libssl-1_1-x64.dll; DestDir: {app}; Flags: ignoreversion
+Source: {#SSL_DIR}\bin\libcrypto-3-x64.dll; DestDir: {app}; Flags: ignoreversion
+Source: {#SSL_DIR}\bin\libssl-3-x64.dll; DestDir: {app}; Flags: ignoreversion
 
 Source: {#PSQL_DIR}\bin\libpq.dll; DestDir: {app}; Flags: ignoreversion
 Source: {#PSQL_DIR}\bin\libintl-8.dll; DestDir: {app}; Flags: ignoreversion


### PR DESCRIPTION
https://github.com/Quick-Event/quickbox/blob/321f99c92e5da547aa1cd3e84513df3bb02526bc/.github/workflows/c-cpp.yml#L94

-> `mingw-w64-x86_64-openssl` package now ships updated version of SSL .dll libraries    


merge this once the pipeline cache is deleted and windows build starts to fail :)
