### PR TITLE
OResults improvements

### DIFF
--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
@@ -115,9 +115,8 @@ void OResultsClient::sendFile(QString name, QString request_path, QString file) 
 	QHttpMultiPart *multi_part = new QHttpMultiPart(QHttpMultiPart::FormDataType);
 
 	QHttpPart api_key_part;
-	auto api_key = settings().apiKey();
 	api_key_part.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"apiKey\""));
-	api_key_part.setBody(api_key.toUtf8());
+	api_key_part.setBody(apiKey().toUtf8());
 
 	QHttpPart file_part;
 	file_part.setHeader(QNetworkRequest::ContentTypeHeader, QVariant("application/gzip"));
@@ -163,10 +162,21 @@ void OResultsClient::onDbEventNotify(const QString &domain, int connection_id, c
 	}
 }
 
+QString OResultsClient::apiKey() const
+{
+	return getPlugin<EventPlugin>()->eventConfig()->value("oresults.apiKey").toString();
+}
+
+void OResultsClient::setApiKey(QString apiKey)
+{
+	getPlugin<EventPlugin>()->eventConfig()->setValue("oresults.apiKey", apiKey);
+	getPlugin<EventPlugin>()->eventConfig()->save("oresults");
+}
+
 void OResultsClient::sendCompetitorChange(QString xml) {
 	QUrl url(API_URL + "/meos");
 	QNetworkRequest request(url);
-	request.setRawHeader("pwd", settings().apiKey().toUtf8());
+	request.setRawHeader("pwd", apiKey().toUtf8());
 	request.setHeader( QNetworkRequest::ContentTypeHeader, "application/gzip" );
 	QNetworkReply *reply = m_networkManager->post(request, gzipCompress(xml.toUtf8()));
 

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
@@ -53,7 +53,8 @@ QString OResultsClient::serviceName()
 
 void OResultsClient::run() {
 	Super::run();
-	onExportTimerTimeOut();
+	exportStartListIofXml3();
+	exportResultsIofXml3();
 	m_exportTimer->start();
 }
 

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
@@ -120,9 +120,9 @@ void OResultsClient::sendFile(QString name, QString request_path, QString file) 
 	api_key_part.setBody(apiKey().toUtf8());
 
 	QHttpPart file_part;
-	file_part.setHeader(QNetworkRequest::ContentTypeHeader, QVariant("application/gzip"));
+	file_part.setHeader(QNetworkRequest::ContentTypeHeader, QVariant("application/zlib"));
 	file_part.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"file\""));
-	file_part.setBody(gzipCompress(file.toUtf8()));
+	file_part.setBody(zlibCompress(file.toUtf8()));
 
 	multi_part->append(api_key_part);
 	multi_part->append(file_part);
@@ -178,8 +178,8 @@ void OResultsClient::sendCompetitorChange(QString xml) {
 	QUrl url(API_URL + "/meos");
 	QNetworkRequest request(url);
 	request.setRawHeader("pwd", apiKey().toUtf8());
-	request.setHeader( QNetworkRequest::ContentTypeHeader, "application/gzip" );
-	QNetworkReply *reply = m_networkManager->post(request, gzipCompress(xml.toUtf8()));
+	request.setHeader( QNetworkRequest::ContentTypeHeader, "application/zlib" );
+	QNetworkReply *reply = m_networkManager->post(request, zlibCompress(xml.toUtf8()));
 
 	connect(reply, &QNetworkReply::finished, reply, [reply]()
 	{
@@ -326,49 +326,13 @@ void OResultsClient::onCompetitorChanged(int competitor_id)
 	}
 }
 
-QByteArray OResultsClient::gzipCompress(QByteArray data)
+QByteArray OResultsClient::zlibCompress(QByteArray data)
 {
-	// calc crc32 helper func
-	auto crc32 = [](char *buf, uint32_t len){
-		uint32_t val, crc;
-		uint8_t i;
-
-		crc = 0xFFFFFFFF;
-		while(len--){
-			val=(crc^*buf++)&0xFF;
-			for(i=0; i<8; i++){
-				val = val & 1 ? (val>>1)^0xEDB88320 : val>>1;
-			}
-			crc = val^crc>>8;
-		}
-		return crc^0xFFFFFFFF;
-	};
-
 	QByteArray compressedData = qCompress(data);
-	//  Strip the first six bytes (a 4-byte length put on by qCompress and a 2-byte zlib header)
-	// and the last four bytes (a zlib integrity check).
-	compressedData.remove(0, 6);
-	compressedData.chop(4);
-
-	QByteArray header;
-	QDataStream ds1(&header, QIODevice::WriteOnly);
-	// Prepend a generic 10-byte gzip header (see RFC 1952),
-	ds1 << quint16(0x1f8b)
-		<< quint16(0x0800)
-		<< quint16(0x0000)
-		<< quint16(0x0000)
-		<< quint16(0x000b);
-
-
-	// Append a four-byte CRC-32 of the uncompressed data
-	// Append 4 bytes uncompressed input size modulo 2^32
-	QByteArray footer;
-	QDataStream ds2(&footer, QIODevice::WriteOnly);
-	ds2.setByteOrder(QDataStream::LittleEndian);
-	ds2 << crc32(data.data(), data.length())
-		<< quint32(data.size());
-
-	return header + compressedData + footer;
+	// strip the 4-byte length put on by qCompress
+	// internally qCompress uses zlib
+	compressedData.remove(0, 4);
+	return compressedData;
 }
 
 }}

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
@@ -51,6 +51,7 @@ private:
 	void sendFile(QString name, QString request_path, QString file);
 	void sendCompetitorChange(QString xml);
 	void onCompetitorChanged(int competitor_id);
+	QByteArray gzipCompress(QByteArray data);
 };
 
 }}

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
@@ -15,7 +15,6 @@ class OResultsClientSettings : public ServiceSettings
 {
 	using Super = ServiceSettings;
 
-	QF_VARIANTMAP_FIELD(QString, a, setA, piKey)
 	QF_VARIANTMAP_FIELD2(int, e, setE, xportIntervalSec, 60)
 public:
 	OResultsClientSettings(const QVariantMap &o = QVariantMap()) : Super(o) {}
@@ -39,7 +38,8 @@ public:
 	void exportStartListIofXml3();
 	void loadSettings() override;
 	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
-
+	QString apiKey() const;
+	void setApiKey(QString apiKey);
 private:
 	QTimer *m_exportTimer = nullptr;
 	QNetworkAccessManager *m_networkManager = nullptr;

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
@@ -51,7 +51,7 @@ private:
 	void sendFile(QString name, QString request_path, QString file);
 	void sendCompetitorChange(QString xml);
 	void onCompetitorChanged(int competitor_id);
-	QByteArray gzipCompress(QByteArray data);
+	QByteArray zlibCompress(QByteArray data);
 };
 
 }}

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclientwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclientwidget.cpp
@@ -24,7 +24,7 @@ OResultsClientWidget::OResultsClientWidget(QWidget *parent)
 	if(svc) {
 		OResultsClientSettings ss = svc->settings();
 		ui->edExportInterval->setValue(ss.exportIntervalSec());
-		ui->edApiKey->setText(ss.apiKey());
+		ui->edApiKey->setText(svc->apiKey());
 	}
 
 	connect(ui->btExportResultsXml30, &QPushButton::clicked, this, &OResultsClientWidget::onBtExportResultsXml30Clicked);
@@ -59,8 +59,7 @@ bool OResultsClientWidget::saveSettings()
 	if(svc) {
 		OResultsClientSettings ss = svc->settings();
 		ss.setExportIntervalSec(ui->edExportInterval->value());
-		ss.setApiKey(ui->edApiKey->text().trimmed());
-
+		svc->setApiKey(ui->edApiKey->text().trimmed());
 		svc->setSettings(ss);
 	}
 	return true;


### PR DESCRIPTION
1. save API key persistently in DB (`config` table). 
API key was saved in settings, which were not event specific and results could be uploaded by mistake to wrong event due to presence of API key from other previously opened event. now it is saved in DB, independently for each event.

2. compress XML payload with zlib to save bandwidth