### PR TITLE
fix: askYesNo dialog

### DIFF
--- a/libqf/libqfqmlwidgets/src/dialogs/messagebox.cpp
+++ b/libqf/libqfqmlwidgets/src/dialogs/messagebox.cpp
@@ -66,9 +66,9 @@ void MessageBox::showInfo(QWidget *parent, const QString &message)
 
 bool MessageBox::askYesNo(QWidget *parent, const QString &msg, bool default_ret)
 {
-	auto i_def = (default_ret)? StandardButton::No: StandardButton::Yes;
+	auto i_def = (default_ret) ? StandardButton::No : StandardButton::Yes;
 	int i = QMessageBox::question(parent, tr("Question"), msg, StandardButtons(Yes | No), i_def);
-	return i == 0;
+	return i == StandardButton::Yes;
 }
 
 bool MessageBox::loadShowAgainDisabled()

--- a/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/eventplugin.cpp
@@ -1251,7 +1251,7 @@ void EventPlugin::importEvent_qbe()
 		qfd::MessageBox::showError(fwk, err_str);
 		return;
 	}
-	if(qfd::MessageBox::askYesNo(fwk, tr("Open imported event '%1'?").arg(event_name))) {
+	if(qfd::MessageBox::askYesNo(fwk, tr("Open imported event '%1'?").arg(event_name), false)) {
 		openEvent(event_name);
 	}
 }


### PR DESCRIPTION
When finding out why the dialog "Open imported event" is not working properly - the event would not open after clicking the `Yes` button - I discovered a bug in the [libqf/libqfqmlwidgets/src/dialogs/messagebox.cpp](https://github.com/Quick-Event/quickbox/compare/master...otahirs:fixYesNoDialog?expand=1#diff-f68f08752bf51888d6da1c34dabd375bd40a7cfc92504ad38b0a63f9b796e436)

In addition I have set the default option for `Open imported event` as `Yes`