### PR TITLE
fix(OResults): serialize xml uploads, suport for multistage events

### DIFF
--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
@@ -261,7 +261,6 @@ void OResultsClient::onCompetitorChanged(int competitor_id)
 	if (competitor_id == 0)
 		return;
 
-	int stage_id = getPlugin<RunsPlugin>()->selectedStageId();
 	qf::core::sql::Query q;
 	q.exec("SELECT competitors.registration, "
 		   "competitors.startNumber, "
@@ -281,7 +280,7 @@ void OResultsClient::onCompetitorChanged(int competitor_id)
 		   "INNER JOIN competitors ON competitors.id = runs.competitorId "
 		   "LEFT JOIN relays ON relays.id = runs.relayId  "
 		   "INNER JOIN classes ON classes.id = competitors.classId OR classes.id = relays.classId  "
-		   "WHERE competitors.id=" QF_IARG(competitor_id) " AND runs.stageId=" QF_IARG(stage_id), qf::core::Exception::Throw);
+		   "WHERE competitors.id=" QF_IARG(competitor_id) " AND runs.stageId=" QF_IARG(stageId()), qf::core::Exception::Throw);
 	if(q.next()) {
 		QString registration = q.value("registration").toString();
 		int start_num = q.value("startNumber").toInt();

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
@@ -54,7 +54,7 @@ QString OResultsClient::serviceName()
 void OResultsClient::run() {
 	Super::run();
 	exportStartListIofXml3();
-	exportResultsIofXml3();
+	QTimer::singleShot(1000, this, &OResultsClient::exportResultsIofXml3);
 	m_exportTimer->start();
 }
 

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
@@ -34,8 +34,8 @@ public:
 
 	static QString serviceName();
 
-	void exportResultsIofXml3();
-	void exportStartListIofXml3();
+	void exportResultsIofXml3(int stage_id);
+	void exportStartListIofXml3(int stage_id);
 	void loadSettings() override;
 	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
 	QString apiKey() const;
@@ -52,6 +52,8 @@ private:
 	void sendCompetitorChange(QString xml);
 	void onCompetitorChanged(int competitor_id);
 	QByteArray zlibCompress(QByteArray data);
+	void setStageId(int stage_id);
+	int stageId() const;
 };
 
 }}

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
@@ -34,8 +34,8 @@ public:
 
 	static QString serviceName();
 
-	void exportResultsIofXml3(int stage_id);
-	void exportStartListIofXml3(int stage_id, std::function<void()> on_success = nullptr);
+	void exportResultsIofXml3();
+	void exportStartListIofXml3(std::function<void()> on_success = nullptr);
 	void loadSettings() override;
 	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
 	QString apiKey() const;
@@ -52,8 +52,6 @@ private:
 	void sendCompetitorChange(QString xml);
 	void onCompetitorChanged(int competitor_id);
 	QByteArray zlibCompress(QByteArray data);
-	void setStageId(int stage_id);
-	int stageId() const;
 };
 
 }}

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.h
@@ -35,7 +35,7 @@ public:
 	static QString serviceName();
 
 	void exportResultsIofXml3(int stage_id);
-	void exportStartListIofXml3(int stage_id);
+	void exportStartListIofXml3(int stage_id, std::function<void()> on_success = nullptr);
 	void loadSettings() override;
 	void onDbEventNotify(const QString &domain, int connection_id, const QVariant &data);
 	QString apiKey() const;
@@ -48,7 +48,7 @@ private:
 	qf::qmlwidgets::framework::DialogWidget *createDetailWidget() override;
 	void onExportTimerTimeOut();
 	void init();
-	void sendFile(QString name, QString request_path, QString file);
+	void sendFile(QString name, QString request_path, QString file, std::function<void()> on_success = nullptr);
 	void sendCompetitorChange(QString xml);
 	void onCompetitorChanged(int competitor_id);
 	QByteArray zlibCompress(QByteArray data);

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclientwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclientwidget.cpp
@@ -8,6 +8,8 @@
 #include <qf/core/assert.h>
 
 #include <QFileDialog>
+
+#include <plugins/Event/src/eventplugin.h>
 using qf::qmlwidgets::framework::getPlugin;
 
 namespace Event {
@@ -70,7 +72,8 @@ void OResultsClientWidget::onBtExportResultsXml30Clicked()
 	OResultsClient *svc = service();
 	if(svc) {
 		saveSettings();
-		svc->exportResultsIofXml3();
+		int current_stage = getPlugin<EventPlugin>()->eventConfig()->currentStageId();
+		svc->exportResultsIofXml3(current_stage);
 	}
 }
 
@@ -79,7 +82,8 @@ void OResultsClientWidget::onBtExportStartListXml30Clicked()
 	OResultsClient *svc = service();
 	if(svc) {
 		saveSettings();
-		svc->exportStartListIofXml3();
+		int current_stage = getPlugin<EventPlugin>()->eventConfig()->currentStageId();
+		svc->exportStartListIofXml3(current_stage);
 	}
 }
 }}

--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclientwidget.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclientwidget.cpp
@@ -72,8 +72,7 @@ void OResultsClientWidget::onBtExportResultsXml30Clicked()
 	OResultsClient *svc = service();
 	if(svc) {
 		saveSettings();
-		int current_stage = getPlugin<EventPlugin>()->eventConfig()->currentStageId();
-		svc->exportResultsIofXml3(current_stage);
+		svc->exportResultsIofXml3();
 	}
 }
 
@@ -82,8 +81,7 @@ void OResultsClientWidget::onBtExportStartListXml30Clicked()
 	OResultsClient *svc = service();
 	if(svc) {
 		saveSettings();
-		int current_stage = getPlugin<EventPlugin>()->eventConfig()->currentStageId();
-		svc->exportStartListIofXml3(current_stage);
+		svc->exportStartListIofXml3();
 	}
 }
 }}


### PR DESCRIPTION
1. make sure results and startlist does not upload to the server in the same timeframe. ~~not the best kind of serialization, but the delay should be enough.~~
2. support multi-stage events

~~2. save the `stage_id` when service was started. so change of stage does not affect the periodic exports~~
