### PR TITLE
fix: include correct version of ssl libs for windows build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -77,8 +77,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          C:/Program Files/OpenSSL-Win64/bin/libssl-1_1-x64.dll
-          C:/Program Files/OpenSSL-Win64/bin/libcrypto-1_1-x64.dll
+          C:/openssl/bin/libssl-1_1-x64.dll
+          C:/openssl/bin/libcrypto-1_1-x64.dll
           C:/msys64/mingw64/bin/libiconv-2.dll
           C:/msys64/mingw64/bin/libintl-8.dll
           C:/msys64/mingw64/bin/libxml2-2.dll
@@ -90,7 +90,7 @@ jobs:
     - name: Get OpenSSL and PostgreSQL libraries
       if: steps.cache-libs.outputs.cache-hit != 'true'
       run: |
-        choco install openssl --version 1.1.1.2000 -y
+        choco install openssl.light --params "/InstallDir:C:\openssl" --version 1.1.1 -y
         C:/msys64/usr/bin/pacman -Sy --noconfirm
         C:/msys64/usr/bin/pacman -S mingw-w64-x86_64-postgresql --noconfirm
       shell: cmd
@@ -127,7 +127,7 @@ jobs:
     - name: Create installer
       run: |
         choco install innosetup --no-progress
-        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" "/DVERSION=%VERSION%" "/DQT_DIR=%Qt5_Dir%" "/DPSQL_DIR=C:\msys64\mingw64" "/DSSL_DIR=C:\Program Files\OpenSSL-Win64\bin" quickevent/quickevent.iss
+        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" "/DVERSION=%VERSION%" "/DQT_DIR=%Qt5_Dir%" "/DPSQL_DIR=C:\msys64\mingw64" "/DSSL_DIR=C:\openssl\bin" quickevent/quickevent.iss
       shell: cmd
 
     - name: Save setup

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -77,8 +77,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          C:/Program Files/OpenSSL-Win64/libssl-1_1-x64.dll
-          C:/Program Files/OpenSSL-Win64/libcrypto-1_1-x64.dll
+          C:/Program Files/OpenSSL-Win64/bin/libssl-1_1-x64.dll
+          C:/Program Files/OpenSSL-Win64/bin/libcrypto-1_1-x64.dll
           C:/msys64/mingw64/bin/libiconv-2.dll
           C:/msys64/mingw64/bin/libintl-8.dll
           C:/msys64/mingw64/bin/libxml2-2.dll
@@ -94,6 +94,10 @@ jobs:
         C:/msys64/usr/bin/pacman -Sy --noconfirm
         C:/msys64/usr/bin/pacman -S mingw-w64-x86_64-postgresql --noconfirm
       shell: cmd
+      
+    - name: Debug
+      run: where /r c:\ libssl-1_1-x64.dll
+      shell: cmd   
 
     - name: Cache Qt
       id: cache-qt
@@ -123,7 +127,7 @@ jobs:
     - name: Create installer
       run: |
         choco install innosetup --no-progress
-        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" "/DVERSION=%VERSION%" "/DQT_DIR=%Qt5_Dir%" "/DPSQL_DIR=C:\msys64\mingw64" "/DSSL_DIR=C:\Program Files\OpenSSL-Win64" quickevent/quickevent.iss
+        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" "/DVERSION=%VERSION%" "/DQT_DIR=%Qt5_Dir%" "/DPSQL_DIR=C:\msys64\mingw64" "/DSSL_DIR=C:\Program Files\OpenSSL-Win64\bin" quickevent/quickevent.iss
       shell: cmd
 
     - name: Save setup

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -97,12 +97,12 @@ jobs:
 
     - name: Cache Qt
       id: cache-qt
+      uses: actions/cache@v2
+      with:
         path: ${{ runner.workspace }}\Qt
         key: ${{ runner.os }}-Qt-${{ env.QT_VERSION }}
 
     - name: Install Qt
-      uses: actions/cache@v2
-      with:
       uses: jurplel/install-qt-action@v2
       with:
         cached: ${{ steps.cache-qt.outputs.cache-hit }}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -77,8 +77,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          C:/msys64/mingw64/bin/libcrypto-3-x64.dll
-          C:/msys64/mingw64/bin/libssl-3-x64.dll
+          C:/Windows/System32/libssl-1_1-x64.dll
+          C:/Windows/System32/libcrypto-1_1-x64.dll
           C:/msys64/mingw64/bin/libiconv-2.dll
           C:/msys64/mingw64/bin/libintl-8.dll
           C:/msys64/mingw64/bin/libxml2-2.dll
@@ -90,8 +90,9 @@ jobs:
     - name: Get OpenSSL and PostgreSQL libraries
       if: steps.cache-libs.outputs.cache-hit != 'true'
       run: |
+        choco install openssl --version 1.1.1.2000 -y
         C:/msys64/usr/bin/pacman -Sy --noconfirm
-        C:/msys64/usr/bin/pacman -S mingw-w64-x86_64-openssl mingw-w64-x86_64-postgresql --noconfirm
+        C:/msys64/usr/bin/pacman -S mingw-w64-x86_64-postgresql --noconfirm
       shell: cmd
 
     - name: Cache Qt
@@ -122,7 +123,7 @@ jobs:
     - name: Create installer
       run: |
         choco install innosetup --no-progress
-        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" "/DVERSION=%VERSION%" "/DQT_DIR=%Qt5_Dir%" "/DPSQL_DIR=C:\msys64\mingw64" "/DSSL_DIR=C:\msys64\mingw64" quickevent/quickevent.iss 
+        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" "/DVERSION=%VERSION%" "/DQT_DIR=%Qt5_Dir%" "/DPSQL_DIR=C:\msys64\mingw64" "/DSSL_DIR=C:\Windows\System32" quickevent/quickevent.iss
       shell: cmd
 
     - name: Save setup

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -94,19 +94,15 @@ jobs:
         C:/msys64/usr/bin/pacman -Sy --noconfirm
         C:/msys64/usr/bin/pacman -S mingw-w64-x86_64-postgresql --noconfirm
       shell: cmd
-      
-    - name: Debug
-      run: where /r c:\ libssl-1_1-x64.dll
-      shell: cmd   
 
     - name: Cache Qt
       id: cache-qt
-      uses: actions/cache@v2
-      with:
         path: ${{ runner.workspace }}\Qt
         key: ${{ runner.os }}-Qt-${{ env.QT_VERSION }}
 
     - name: Install Qt
+      uses: actions/cache@v2
+      with:
       uses: jurplel/install-qt-action@v2
       with:
         cached: ${{ steps.cache-qt.outputs.cache-hit }}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -77,8 +77,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          C:/Windows/System32/libssl-1_1-x64.dll
-          C:/Windows/System32/libcrypto-1_1-x64.dll
+          C:/Program Files/OpenSSL-Win64/libssl-1_1-x64.dll
+          C:/Program Files/OpenSSL-Win64/libcrypto-1_1-x64.dll
           C:/msys64/mingw64/bin/libiconv-2.dll
           C:/msys64/mingw64/bin/libintl-8.dll
           C:/msys64/mingw64/bin/libxml2-2.dll
@@ -123,7 +123,7 @@ jobs:
     - name: Create installer
       run: |
         choco install innosetup --no-progress
-        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" "/DVERSION=%VERSION%" "/DQT_DIR=%Qt5_Dir%" "/DPSQL_DIR=C:\msys64\mingw64" "/DSSL_DIR=C:\Windows\System32" quickevent/quickevent.iss
+        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" "/DVERSION=%VERSION%" "/DQT_DIR=%Qt5_Dir%" "/DPSQL_DIR=C:\msys64\mingw64" "/DSSL_DIR=C:\Program Files\OpenSSL-Win64" quickevent/quickevent.iss
       shell: cmd
 
     - name: Save setup

--- a/quickevent/quickevent.iss
+++ b/quickevent/quickevent.iss
@@ -59,8 +59,8 @@ Source: {#SRC_DIR}\quickevent\app\quickevent\datafiles\*; DestDir: {app}\quickev
 
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
-Source: {#SSL_DIR}\bin\libcrypto-3-x64.dll; DestDir: {app}; Flags: ignoreversion
-Source: {#SSL_DIR}\bin\libssl-3-x64.dll; DestDir: {app}; Flags: ignoreversion
+Source: {#SSL_DIR}\libcrypto-1_1-x64.dll; DestDir: {app}; Flags: ignoreversion
+Source: {#SSL_DIR}\libssl-1_1-x64.dll; DestDir: {app}; Flags: ignoreversion
 
 Source: {#PSQL_DIR}\bin\libpq.dll; DestDir: {app}; Flags: ignoreversion
 Source: {#PSQL_DIR}\bin\libintl-8.dll; DestDir: {app}; Flags: ignoreversion


### PR DESCRIPTION
budle correct version of SSL libraries for windows build.  
tested on W10 (Version 10.0.19045 Build 19045)
