### PR TITLE
fix: ssl libs cache

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,17 +17,10 @@ jobs:
       with:
         submodules: 'recursive'
 
-    - name: Cache Qt
-      id: cache-qt
-      uses: actions/cache@v3
-      with:
-        path: ${{ runner.workspace }}/Qt
-        key: ${{ runner.os }}-Qt-${{ env.QT_VERSION }}
-
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:
-        cached: ${{ steps.cache-qt.outputs.cache-hit }}
+        cache: 'true'
         version: ${{ env.QT_VERSION }}
         host: 'linux'
 
@@ -95,17 +88,10 @@ jobs:
         C:/msys64/usr/bin/pacman -S mingw-w64-x86_64-postgresql --noconfirm
       shell: cmd
 
-    - name: Cache Qt
-      id: cache-qt
-      uses: actions/cache@v3
-      with:
-        path: ${{ runner.workspace }}\Qt
-        key: ${{ runner.os }}-Qt-${{ env.QT_VERSION }}
-
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:
-        cached: ${{ steps.cache-qt.outputs.cache-hit }}
+        cache: 'true'
         version: ${{ env.QT_VERSION }}
         host: 'windows'
         arch: 'win64_mingw81'

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,19 +13,19 @@ jobs:
   build_linux:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
     - name: Cache Qt
       id: cache-qt
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ runner.workspace }}/Qt
         key: ${{ runner.os }}-Qt-${{ env.QT_VERSION }}
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         version: ${{ env.QT_VERSION }}
@@ -49,13 +49,13 @@ jobs:
         ./quickevent/make-dist.sh --src-dir . --qt-dir ${Qt5_DIR} --work-dir ./build --appimage-tool /opt/appimagetool-x86_64.AppImage 
 
     - name: Save AppImage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: quickevent-${{ env.VERSION }}-linux64.Appimage
         path: build/artifacts/quickevent-*-linux64.AppImage
 
     - name: Save gzip
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: quickevent-${{ env.VERSION }}-linux64.tgz
         path: build/artifacts/quickevent-*-linux64.tgz
@@ -68,13 +68,13 @@ jobs:
         shell: bash
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
     - name: Cache Libs
       id: cache-libs
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           C:/openssl/bin/libssl-1_1-x64.dll
@@ -97,13 +97,13 @@ jobs:
 
     - name: Cache Qt
       id: cache-qt
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ runner.workspace }}\Qt
         key: ${{ runner.os }}-Qt-${{ env.QT_VERSION }}
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       with:
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
         version: ${{ env.QT_VERSION }}
@@ -127,7 +127,7 @@ jobs:
       shell: cmd
 
     - name: Save setup
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: quickevent-${{ env.VERSION }}-win64-setup.exe
         path: _inno\quickevent\quickevent-${{ env.VERSION }}-win64-setup.exe


### PR DESCRIPTION
pipelines for windows are failing due to github action having trouble with cache path used for ssl library dlls.  
I updated the pipeline with new version of cache action to fix that issue, and while at it I updated all github actions versions.