### PR TITLE
fix(OResults): unify runner_id

### DIFF
--- a/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/oresultsclient.cpp
@@ -286,11 +286,11 @@ void OResultsClient::onCompetitorChanged(int competitor_id)
 		int start_time = q.value("startTimeMs").toInt();
 		int running_time = q.value("timeMs").toInt();
 
-		QString runner_id = is_csos_reg(registration) ? registration : QString::number(card_num);
-		int status_code = mop_run_status_code(running_time, isDisq, isDisqByOrganizer, isMissPunch, isBadCheck, isDidNotStart, isDidNotFinish, isNotCompeting);
-
-		if (runner_id.isEmpty() || card_num == 0)
+		if (registration.isEmpty() && card_num == 0)
 			return;
+
+		QString runner_id = !registration.isEmpty() ? registration : QString::number(card_num);
+		int status_code = mop_run_status_code(running_time, isDisq, isDisqByOrganizer, isMissPunch, isBadCheck, isDidNotStart, isDidNotFinish, isNotCompeting);
 
 		QVariantMap competitor {
 			{"stat", status_code},

--- a/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
@@ -467,7 +467,7 @@ QVariant RelaysPlugin::startListByClassesTableData(const QString &class_filter)
 		qf::core::sql::QueryBuilder qb;
 		qb.select2("competitors", "registration, iofId")
 			.select("competitors.firstName, competitors.lastName, COALESCE(competitors.lastName, '') || ' ' || COALESCE(competitors.firstName, '') AS competitorName")
-			.select2("runs", "leg, siId, startTimeMs")
+			.select2("runs", "id, leg, siId, startTimeMs")
 			.from("runs")
 			.join("runs.competitorId", "competitors.id")
 			.join("runs.relayId", "relays.id")
@@ -604,6 +604,7 @@ QString RelaysPlugin::resultsIofXml30()
 					continue;
 				QVariantList member_result{"TeamMemberResult"};
 				QVariantList person{"Person"};
+				append_list(person, QVariantList{"Id", tt_leg_row.value(QStringLiteral("runId"))});
 				append_list(person, QVariantList{"Id", QVariantMap{{"type", "CZE"}}, tt_leg_row.value(QStringLiteral("registration"))});
 				auto iof_id = tt_leg_row.value(QStringLiteral("iofId"));
 				if (!iof_id.isNull())
@@ -809,6 +810,7 @@ QString RelaysPlugin::startListIofXml30()
 				const qf::core::utils::TreeTableRow tt_leg_row = tt_legs.row(k);
 				QVariantList member_start{"TeamMemberStart"};
 				QVariantList person{"Person"};
+				append_list(person, QVariantList{"Id", tt_leg_row.value(QStringLiteral("runs.id"))});
 				append_list(person, QVariantList{"Id", QVariantMap{{"type", "CZE"}}, tt_leg_row.value(QStringLiteral("registration"))});
 				auto iof_id = tt_leg_row.value(QStringLiteral("iofId"));
 				if (!iof_id.isNull())

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -866,6 +866,8 @@ QString RunsPlugin::resultsIofXml30Stage(int stage_id)
 		QVariantList person_result{"PersonResult"};
 		QVariantList person{"Person"};
 		person.insert(person.count(),
+			QVariantList{"Id", tt2_row.value(QStringLiteral("runs.id"))});
+		person.insert(person.count(),
 			QVariantList{"Id", QVariantMap{{"type", "CZE"}}, tt2_row.value(QStringLiteral("competitors.registration"))});
 		auto iof_id = tt2_row.value(QStringLiteral("competitors.iofId"));
 		if (!iof_id.isNull())
@@ -1120,7 +1122,7 @@ qf::core::utils::TreeTable RunsPlugin::startListClassesTable(const QString &wher
 	qfs::QueryBuilder qb2;
 	qb2.select2("competitors", "lastName, firstName, registration, iofId, startNumber")
 		.select("COALESCE(competitors.lastName, '') || ' ' || COALESCE(competitors.firstName, '') AS competitorName")
-		.select2("runs", "siId, startTimeMs")
+		.select2("runs", "id, siId, startTimeMs")
 		.select2("clubs","name, abbr")
 		.from("competitors")
 		.join("LEFT JOIN clubs ON substr(competitors.registration, 1, 3) = clubs.abbr")
@@ -2372,6 +2374,7 @@ QString RunsPlugin::startListStageIofXml30(int stage_id)
 			auto tt2_row = tt2.row(j);
 			QVariantList xml_person{"PersonStart"};
 			QVariantList person{"Person"};
+			append_list(person, QVariantList{"Id", tt2_row.value(QStringLiteral("runs.id"))});
 			append_list(person, QVariantList{"Id", QVariantMap{{"type", "CZE"}}, tt2_row.value(QStringLiteral("competitors.registration"))});
 			auto iof_id = tt2_row.value(QStringLiteral("competitors.iofId"));
 			if (!iof_id.isNull())

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define APP_VERSION "2.6.21"
+#define APP_VERSION "2.6.22"
 


### PR DESCRIPTION
unify runner id exports to OResults across start-list/results upload and `onCompetitorChanged`  

currently in start-list/results uploads, runners can be exported with ORIS temporary entry number  
 but in `onCompetitorChanged` these are not considered valid and card_num is used instead
this creates problems as runners with ORIS temporary entry number are not exported under one unique Id  

to solve this, `onCompetitorChanged`  has been changed to allow for ORIS temporary entry number
