### PR TITLE
fix: ??? in RunStatus

### DIFF
--- a/libquickevent/libquickeventcore/src/runstatus.cpp
+++ b/libquickevent/libquickeventcore/src/runstatus.cpp
@@ -43,8 +43,6 @@ bool RunStatus::isOk() const
 
 int RunStatus::toTime() const
 {
-	if (m_notCompeting)
-		return quickevent::core::og::TimeMs::NOT_COMPETITING_TIME_MSEC;
 	if (m_disqualified) {
 		if (m_missingPunch)
 			return quickevent::core::og::TimeMs::MISPUNCH_TIME_MSEC;
@@ -58,13 +56,13 @@ int RunStatus::toTime() const
 		//
 		return quickevent::core::og::TimeMs::DISQ_TIME_MSEC;
 	}
+	if (m_notCompeting)
+		return quickevent::core::og::TimeMs::NOT_COMPETITING_TIME_MSEC;
 	return 0;
 }
 
 QString RunStatus::toXmlExportString() const
 {
-	if (m_notCompeting)
-		return QStringLiteral("NotCompeting");
 	if (m_disqualified) {
 		if (m_missingPunch)
 			return QStringLiteral("MissingPunch");
@@ -78,14 +76,14 @@ QString RunStatus::toXmlExportString() const
 		//
 		return QStringLiteral("Disqualified");
 	}
+	if (m_notCompeting)
+		return QStringLiteral("NotCompeting");
 	return QStringLiteral("OK");
 }
 
 
 QString RunStatus::toEmmaExportString() const
 {
-	if (m_notCompeting)
-		return QStringLiteral("NC  ");
 	if (m_disqualified)	{
 		if (m_missingPunch)
 			return QStringLiteral("MP  ");
@@ -99,13 +97,13 @@ QString RunStatus::toEmmaExportString() const
 		//
 		return QStringLiteral("DISQ");
 	}
+	if (m_notCompeting)
+		return QStringLiteral("NC  ");
 	return QStringLiteral("O.K.");
 }
 
 QString RunStatus::toHtmlExportString() const
 {
-	if (m_notCompeting)
-		return QStringLiteral("NC");
 	if (m_disqualified)	{
 		if (m_missingPunch)
 			return QStringLiteral("MP");
@@ -119,13 +117,13 @@ QString RunStatus::toHtmlExportString() const
 		//
 		return QStringLiteral("DISQ");
 	}
+	if (m_notCompeting)
+		return QStringLiteral("NC");
 	return QStringLiteral("OK");
 }
 
 QString RunStatus::toString() const
 {
-	if (m_notCompeting)
-		return tr("NC", "Not Competing");
 	if (m_disqualified)	{
 		if (m_missingPunch)
 			return tr("MP", "Missing Punch");
@@ -139,6 +137,8 @@ QString RunStatus::toString() const
 		//
 		return tr("DISQ", "Disqualified");
 	}
+	if (m_notCompeting)
+		return tr("NC", "Not Competing");
 	return tr("OK");
 }
 

--- a/libquickevent/libquickeventcore/src/runstatus.cpp
+++ b/libquickevent/libquickeventcore/src/runstatus.cpp
@@ -43,113 +43,103 @@ bool RunStatus::isOk() const
 
 int RunStatus::toTime() const
 {
-	if (m_disqualified) {
-		if (m_disqualifiedByOrganizer)
-			return quickevent::core::og::TimeMs::DISQ_TIME_MSEC;
-		else if (m_missingPunch)
-			return quickevent::core::og::TimeMs::MISPUNCH_TIME_MSEC;
-		else if (m_didNotStart)
-			return quickevent::core::og::TimeMs::NOT_START_TIME_MSEC;
-		else if (m_didNotFinish)
-			return quickevent::core::og::TimeMs::NOT_FINISH_TIME_MSEC;
-		else if (m_overTime)
-			return quickevent::core::og::TimeMs::OVERTIME_TIME_MSEC;
-		else
-			return 0;
-	}
-	else if (m_notCompeting)
+	if (m_notCompeting)
 		return quickevent::core::og::TimeMs::NOT_COMPETITING_TIME_MSEC;
-	else
-		return 0;
+	if (m_disqualified) {
+		if (m_missingPunch)
+			return quickevent::core::og::TimeMs::MISPUNCH_TIME_MSEC;
+		if (m_didNotStart)
+			return quickevent::core::og::TimeMs::NOT_START_TIME_MSEC;
+		if (m_didNotFinish)
+			return quickevent::core::og::TimeMs::NOT_FINISH_TIME_MSEC;
+		if (m_overTime)
+			return quickevent::core::og::TimeMs::OVERTIME_TIME_MSEC;
+		// if (m_disqualifiedByOrganizer)
+		//
+		return quickevent::core::og::TimeMs::DISQ_TIME_MSEC;
+	}
+	return 0;
 }
 
 QString RunStatus::toXmlExportString() const
 {
-	if (m_disqualified) {
-		if (m_disqualifiedByOrganizer)
-			return QStringLiteral("Disqualified");
-		else if (m_missingPunch)
-			return QStringLiteral("MissingPunch");
-		else if (m_didNotStart)
-			return QStringLiteral("DidNotStart");
-		else if (m_didNotFinish)
-			return QStringLiteral("DidNotFinish");
-		else if (m_overTime)
-			return QStringLiteral("OverTime");
-		else
-			return QStringLiteral("???");
-	}
-	else if (m_notCompeting)
+	if (m_notCompeting)
 		return QStringLiteral("NotCompeting");
-	else
-		return QStringLiteral("OK");
+	if (m_disqualified) {
+		if (m_missingPunch)
+			return QStringLiteral("MissingPunch");
+		if (m_didNotStart)
+			return QStringLiteral("DidNotStart");
+		if (m_didNotFinish)
+			return QStringLiteral("DidNotFinish");
+		if (m_overTime)
+			return QStringLiteral("OverTime");
+		// if (m_disqualifiedByOrganizer)
+		//
+		return QStringLiteral("Disqualified");
+	}
+	return QStringLiteral("OK");
 }
 
 
 QString RunStatus::toEmmaExportString() const
 {
-	if (m_disqualified)	{
-		if (m_disqualifiedByOrganizer)
-			return QStringLiteral("DISQ");
-		else if (m_missingPunch)
-			return QStringLiteral("MP  ");
-		else if (m_didNotStart)
-			return QStringLiteral("DNS ");
-		else if (m_didNotFinish)
-			return QStringLiteral("DNF ");
-		else if (m_overTime)
-			return QStringLiteral("OVRT");
-		else
-			return QStringLiteral("???");
-	}
-	else if (m_notCompeting)
+	if (m_notCompeting)
 		return QStringLiteral("NC  ");
-	else
-		return QStringLiteral("O.K.");
+	if (m_disqualified)	{
+		if (m_missingPunch)
+			return QStringLiteral("MP  ");
+		if (m_didNotStart)
+			return QStringLiteral("DNS ");
+		if (m_didNotFinish)
+			return QStringLiteral("DNF ");
+		if (m_overTime)
+			return QStringLiteral("OVRT");
+		// if (m_disqualifiedByOrganizer)
+		//
+		return QStringLiteral("DISQ");
+	}
+	return QStringLiteral("O.K.");
 }
 
 QString RunStatus::toHtmlExportString() const
 {
-	if (m_disqualified)	{
-		if (m_disqualifiedByOrganizer)
-			return QStringLiteral("DISQ");
-		else if (m_missingPunch)
-			return QStringLiteral("MP");
-		else if (m_didNotStart)
-			return QStringLiteral("DNS");
-		else if (m_didNotFinish)
-			return QStringLiteral("DNF");
-		else if (m_overTime)
-			return QStringLiteral("OVRT");
-		else
-			return QStringLiteral("???");
-	}
-	else if (m_notCompeting)
+	if (m_notCompeting)
 		return QStringLiteral("NC");
-	else
-		return QStringLiteral("OK");
+	if (m_disqualified)	{
+		if (m_missingPunch)
+			return QStringLiteral("MP");
+		if (m_didNotStart)
+			return QStringLiteral("DNS");
+		if (m_didNotFinish)
+			return QStringLiteral("DNF");
+		if (m_overTime)
+			return QStringLiteral("OVRT");
+		// else if (m_disqualifiedByOrganizer)
+		//
+		return QStringLiteral("DISQ");
+	}
+	return QStringLiteral("OK");
 }
 
 QString RunStatus::toString() const
 {
-	if (m_disqualified)	{
-		if (m_disqualifiedByOrganizer)
-			return tr("DISQ", "Disqualified");
-		else if (m_missingPunch)
-			return tr("MP", "Missing Punch");
-		else if (m_didNotStart)
-			return tr("DNS", "Did Not Start");
-		else if (m_didNotFinish)
-			return tr("DNF", "Did Not Finish");
-		else if (m_overTime)
-			return tr("OVRT", "Over Time");
-		else
-			return QStringLiteral("???");
-	}
-	else if (m_notCompeting)
+	if (m_notCompeting)
 		return tr("NC", "Not Competing");
-	else
-		return tr("OK");
+	if (m_disqualified)	{
+		if (m_missingPunch)
+			return tr("MP", "Missing Punch");
+		if (m_didNotStart)
+			return tr("DNS", "Did Not Start");
+		if (m_didNotFinish)
+			return tr("DNF", "Did Not Finish");
+		if (m_overTime)
+			return tr("OVRT", "Over Time");
+		// if (m_disqualifiedByOrganizer)
+		//
+		return tr("DISQ", "Disqualified");
+	}
+	return tr("OK");
 }
 
 } // namespace core

--- a/libquickevent/libquickeventcore/src/runstatus.cpp
+++ b/libquickevent/libquickeventcore/src/runstatus.cpp
@@ -46,6 +46,8 @@ int RunStatus::toTime() const
 	if (m_notCompeting)
 		return quickevent::core::og::TimeMs::NOT_COMPETITING_TIME_MSEC;
 	if (m_disqualified) {
+		if (m_disqualifiedByOrganizer)
+			return quickevent::core::og::TimeMs::DISQ_TIME_MSEC;
 		if (m_missingPunch)
 			return quickevent::core::og::TimeMs::MISPUNCH_TIME_MSEC;
 		if (m_didNotStart)
@@ -54,8 +56,6 @@ int RunStatus::toTime() const
 			return quickevent::core::og::TimeMs::NOT_FINISH_TIME_MSEC;
 		if (m_overTime)
 			return quickevent::core::og::TimeMs::OVERTIME_TIME_MSEC;
-		// if (m_disqualifiedByOrganizer)
-		//
 		return quickevent::core::og::TimeMs::DISQ_TIME_MSEC;
 	}
 	return 0;
@@ -66,6 +66,8 @@ QString RunStatus::toXmlExportString() const
 	if (m_notCompeting)
 		return QStringLiteral("NotCompeting");
 	if (m_disqualified) {
+		if (m_disqualifiedByOrganizer)
+			QStringLiteral("Disqualified");
 		if (m_missingPunch)
 			return QStringLiteral("MissingPunch");
 		if (m_didNotStart)
@@ -74,8 +76,6 @@ QString RunStatus::toXmlExportString() const
 			return QStringLiteral("DidNotFinish");
 		if (m_overTime)
 			return QStringLiteral("OverTime");
-		// if (m_disqualifiedByOrganizer)
-		//
 		return QStringLiteral("Disqualified");
 	}
 	return QStringLiteral("OK");
@@ -87,6 +87,8 @@ QString RunStatus::toEmmaExportString() const
 	if (m_notCompeting)
 		return QStringLiteral("NC  ");
 	if (m_disqualified)	{
+		if (m_disqualifiedByOrganizer)
+			return QStringLiteral("DISQ");
 		if (m_missingPunch)
 			return QStringLiteral("MP  ");
 		if (m_didNotStart)
@@ -95,8 +97,6 @@ QString RunStatus::toEmmaExportString() const
 			return QStringLiteral("DNF ");
 		if (m_overTime)
 			return QStringLiteral("OVRT");
-		// if (m_disqualifiedByOrganizer)
-		//
 		return QStringLiteral("DISQ");
 	}
 	return QStringLiteral("O.K.");
@@ -107,6 +107,8 @@ QString RunStatus::toHtmlExportString() const
 	if (m_notCompeting)
 		return QStringLiteral("NC");
 	if (m_disqualified)	{
+		if (m_disqualifiedByOrganizer)
+			return QStringLiteral("DISQ");
 		if (m_missingPunch)
 			return QStringLiteral("MP");
 		if (m_didNotStart)
@@ -115,8 +117,6 @@ QString RunStatus::toHtmlExportString() const
 			return QStringLiteral("DNF");
 		if (m_overTime)
 			return QStringLiteral("OVRT");
-		// else if (m_disqualifiedByOrganizer)
-		//
 		return QStringLiteral("DISQ");
 	}
 	return QStringLiteral("OK");
@@ -127,6 +127,8 @@ QString RunStatus::toString() const
 	if (m_notCompeting)
 		return tr("NC", "Not Competing");
 	if (m_disqualified)	{
+		if (m_disqualifiedByOrganizer)
+			return tr("DISQ", "Disqualified");
 		if (m_missingPunch)
 			return tr("MP", "Missing Punch");
 		if (m_didNotStart)
@@ -135,8 +137,6 @@ QString RunStatus::toString() const
 			return tr("DNF", "Did Not Finish");
 		if (m_overTime)
 			return tr("OVRT", "Over Time");
-		// if (m_disqualifiedByOrganizer)
-		//
 		return tr("DISQ", "Disqualified");
 	}
 	return tr("OK");

--- a/libquickevent/libquickeventcore/src/runstatus.cpp
+++ b/libquickevent/libquickeventcore/src/runstatus.cpp
@@ -43,6 +43,8 @@ bool RunStatus::isOk() const
 
 int RunStatus::toTime() const
 {
+	if (m_notCompeting)
+		return quickevent::core::og::TimeMs::NOT_COMPETITING_TIME_MSEC;
 	if (m_disqualified) {
 		if (m_missingPunch)
 			return quickevent::core::og::TimeMs::MISPUNCH_TIME_MSEC;
@@ -56,13 +58,13 @@ int RunStatus::toTime() const
 		//
 		return quickevent::core::og::TimeMs::DISQ_TIME_MSEC;
 	}
-	if (m_notCompeting)
-		return quickevent::core::og::TimeMs::NOT_COMPETITING_TIME_MSEC;
 	return 0;
 }
 
 QString RunStatus::toXmlExportString() const
 {
+	if (m_notCompeting)
+		return QStringLiteral("NotCompeting");
 	if (m_disqualified) {
 		if (m_missingPunch)
 			return QStringLiteral("MissingPunch");
@@ -76,14 +78,14 @@ QString RunStatus::toXmlExportString() const
 		//
 		return QStringLiteral("Disqualified");
 	}
-	if (m_notCompeting)
-		return QStringLiteral("NotCompeting");
 	return QStringLiteral("OK");
 }
 
 
 QString RunStatus::toEmmaExportString() const
 {
+	if (m_notCompeting)
+		return QStringLiteral("NC  ");
 	if (m_disqualified)	{
 		if (m_missingPunch)
 			return QStringLiteral("MP  ");
@@ -97,13 +99,13 @@ QString RunStatus::toEmmaExportString() const
 		//
 		return QStringLiteral("DISQ");
 	}
-	if (m_notCompeting)
-		return QStringLiteral("NC  ");
 	return QStringLiteral("O.K.");
 }
 
 QString RunStatus::toHtmlExportString() const
 {
+	if (m_notCompeting)
+		return QStringLiteral("NC");
 	if (m_disqualified)	{
 		if (m_missingPunch)
 			return QStringLiteral("MP");
@@ -117,13 +119,13 @@ QString RunStatus::toHtmlExportString() const
 		//
 		return QStringLiteral("DISQ");
 	}
-	if (m_notCompeting)
-		return QStringLiteral("NC");
 	return QStringLiteral("OK");
 }
 
 QString RunStatus::toString() const
 {
+	if (m_notCompeting)
+		return tr("NC", "Not Competing");
 	if (m_disqualified)	{
 		if (m_missingPunch)
 			return tr("MP", "Missing Punch");
@@ -137,8 +139,6 @@ QString RunStatus::toString() const
 		//
 		return tr("DISQ", "Disqualified");
 	}
-	if (m_notCompeting)
-		return tr("NC", "Not Competing");
 	return tr("OK");
 }
 

--- a/libquickevent/libquickeventcore/src/runstatus.cpp
+++ b/libquickevent/libquickeventcore/src/runstatus.cpp
@@ -67,7 +67,7 @@ QString RunStatus::toXmlExportString() const
 		return QStringLiteral("NotCompeting");
 	if (m_disqualified) {
 		if (m_disqualifiedByOrganizer)
-			QStringLiteral("Disqualified");
+			return QStringLiteral("Disqualified");
 		if (m_missingPunch)
 			return QStringLiteral("MissingPunch");
 		if (m_didNotStart)

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define APP_VERSION "2.6.22"
+#define APP_VERSION "2.6.23"
 


### PR DESCRIPTION
fix toString methods producing "???" as a result status. Why would we use `???` instead of a default value anyway?  

there is an unsolved question how the runners got `isDisqualified` flag, without any other more concrete flag set in #917