### PR TITLE
fix: include libssl in appimage

### DIFF
--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define APP_VERSION "2.6.23"
+#define APP_VERSION "2.6.24"
 

--- a/quickevent/make-dist.sh
+++ b/quickevent/make-dist.sh
@@ -174,6 +174,8 @@ $RSYNC $QT_LIB_DIR/libQt5SerialPort.so* $DIST_LIB_DIR
 $RSYNC $QT_LIB_DIR/libQt5DBus.so* $DIST_LIB_DIR
 $RSYNC $QT_LIB_DIR/libQt5Multimedia.so* $DIST_LIB_DIR
 $RSYNC $QT_LIB_DIR/libQt5XcbQpa.so* $DIST_LIB_DIR
+$RSYNC /usr/lib/x86_64-linux-gnu/libssl.so $DIST_LIB_DIR
+$RSYNC /usr/lib/x86_64-linux-gnu/libcrypto.so $DIST_LIB_DIR
 
 $RSYNC $QT_LIB_DIR/libicu*.so* $DIST_LIB_DIR
 

--- a/quickevent/make-dist.sh
+++ b/quickevent/make-dist.sh
@@ -174,8 +174,8 @@ $RSYNC $QT_LIB_DIR/libQt5SerialPort.so* $DIST_LIB_DIR
 $RSYNC $QT_LIB_DIR/libQt5DBus.so* $DIST_LIB_DIR
 $RSYNC $QT_LIB_DIR/libQt5Multimedia.so* $DIST_LIB_DIR
 $RSYNC $QT_LIB_DIR/libQt5XcbQpa.so* $DIST_LIB_DIR
-$RSYNC /usr/lib/x86_64-linux-gnu/libssl.so $DIST_LIB_DIR
-$RSYNC /usr/lib/x86_64-linux-gnu/libcrypto.so $DIST_LIB_DIR
+$RSYNC /usr/lib/x86_64-linux-gnu/libssl.so* $DIST_LIB_DIR
+$RSYNC /usr/lib/x86_64-linux-gnu/libcrypto.so* $DIST_LIB_DIR
 
 $RSYNC $QT_LIB_DIR/libicu*.so* $DIST_LIB_DIR
 


### PR DESCRIPTION
temporal fix until Qt6 build gets stable
include libcrypto and libssl (v1.1) from ubuntu 20.04 in the release appimage to support new linux distros that do come only with uncompatible openssl 3.0
close #925 

tested on ubuntu 22.04