### PR TITLE
Fix page layouts & some ReportOptionsDialog improvements

### DIFF
--- a/libquickevent/libquickeventcore/src/codedef.cpp
+++ b/libquickevent/libquickeventcore/src/codedef.cpp
@@ -109,6 +109,12 @@ std::optional<int> CodeDef::codeToStartNumber(int code)
 	return {};
 }
 
+int CodeDef::startNumberToCode(int start)
+{
+	return start + START_PUNCH_CODE;
+}
+
+
 std::optional<int> CodeDef::codeToFinishNumber(int code)
 {
 	if(CodeDef::codeToType(code) == CodeDef::Type::Finish)

--- a/libquickevent/libquickeventcore/src/codedef.h
+++ b/libquickevent/libquickeventcore/src/codedef.h
@@ -45,6 +45,7 @@ public:
 	static Type codeToType(int code);
 	static std::optional<int> codeToStartNumber(int code);
 	static std::optional<int> codeToFinishNumber(int code);
+	static int startNumberToCode(int start);
 
 	QString toString() const;
 };

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
@@ -196,7 +196,6 @@ void ReportOptionsDialog::setOptions(const ReportOptionsDialog::Options &options
 	ui->edPageHeight->setValue(options.pageHeight());
 	ui->edHorizontalMargin->setValue(options.horizontalMargin());
 	ui->edVerticalMargin->setValue(options.verticalMargin());
-	//ui->chkShirinkPageWidthToColumnCount->setChecked(options.isShirinkPageWidthToColumnCount());
 	ui->grpClassFilter->setChecked(options.isUseClassFilter());
 	ui->chkClassFilterDoesntMatch->setChecked(options.isInvertClassFilter());
 	ui->edFilter->setText(options.classFilter());
@@ -233,7 +232,6 @@ ReportOptionsDialog::Options ReportOptionsDialog::options() const
 	opts.setPageHeight(ui->edPageHeight->value());
 	opts.setHorizontalMargin(ui->edHorizontalMargin->value());
 	opts.setVerticalMargin(ui->edVerticalMargin->value());
-	//opts.setShirinkPageWidthToColumnCount(ui->chkShirinkPageWidthToColumnCount->isChecked());
 	opts.setUseClassFilter(ui->grpClassFilter->isChecked());
 	opts.setInvertClassFilter(ui->chkClassFilterDoesntMatch->isChecked());
 	opts.setClassFilter(ui->edFilter->text());

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
@@ -44,6 +44,7 @@ ReportOptionsDialog::ReportOptionsDialog(QWidget *parent)
 	connect(this, &ReportOptionsDialog::persistentSettingsIdChanged, [this]() {
 		loadPersistentSettings();
 	});
+    connect(ui->btReset, &QPushButton::clicked, this, &ReportOptionsDialog::resetPersistentSettings);
 
 	connect(this, &ReportOptionsDialog::startListOptionsVisibleChanged, ui->grpStartOptions, &QGroupBox::setVisible);
 	connect(this, &ReportOptionsDialog::classFilterVisibleChanged, ui->grpClassFilter, &QGroupBox::setVisible);
@@ -327,6 +328,12 @@ ReportOptionsDialog::StartlistOrderFirstBy ReportOptionsDialog::startlistOrderFi
 	return start_order_by;
 }
 
+void ReportOptionsDialog::resetPersistentSettings()
+{
+    Options new_options;
+    setOptions(new_options);
+    savePersistentSettings();
+}
 
 }}
 

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
@@ -146,24 +146,23 @@ bool ReportOptionsDialog::isStartListPrintStartNumbers() const
 	return ui->chkStartOpts_PrintStartNumbers->isChecked();
 }
 
-QString ReportOptionsDialog::sqlWhereExpression() const
+QString ReportOptionsDialog::sqlWhereExpression(const int stage_id) const
 {
 	const Options opts = options();
-	return sqlWhereExpression(opts);
+	return sqlWhereExpression(opts,stage_id);
 }
 
-QString ReportOptionsDialog::getClassesForStartNumber(const int number)
+QString ReportOptionsDialog::getClassesForStartNumber(const int number, const int stage_id)
 {
 	QString classes;
 	if (number > 0) {
 		int start_code = core::CodeDef::startNumberToCode(number);
-		int stage = 1;
 
 		QString query_str = "SELECT classes.name FROM classes, classdefs, coursecodes, codes"
 							" WHERE classdefs.classId = classes.id AND classdefs.courseId = coursecodes.courseId AND"
 							" coursecodes.position = 0 AND coursecodes.codeId = codes.id AND classdefs.stageId = %2 AND codes.code = %1";
 		qf::core::sql::Query q;
-		q.exec(query_str.arg(start_code).arg(stage), qf::core::Exception::Throw);
+		q.exec(query_str.arg(start_code).arg(stage_id), qf::core::Exception::Throw);
 		while (q.next()) {
 			if (!classes.isEmpty())
 				classes += ",";
@@ -173,7 +172,7 @@ QString ReportOptionsDialog::getClassesForStartNumber(const int number)
 	return classes;
 }
 
-QString ReportOptionsDialog::sqlWhereExpression(const ReportOptionsDialog::Options &opts)
+QString ReportOptionsDialog::sqlWhereExpression(const ReportOptionsDialog::Options &opts,const int stage_id)
 {
 	if(opts.isUseClassFilter()) {
 		QString filter_str = opts.classFilter();
@@ -204,7 +203,7 @@ QString ReportOptionsDialog::sqlWhereExpression(const ReportOptionsDialog::Optio
 
 	}
 	else if (opts.isUseClassStartSelectionFilter()) {
-		qf::core::String s = getClassesForStartNumber(opts.classStartNumber());
+		qf::core::String s = getClassesForStartNumber(opts.classStartNumber(),stage_id);
 		QStringList sl = s.splitAndTrim(',');
 		QString ret = QString("classes.name IN('%2')").arg(sl.join("','"));
 		return ret;

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.cpp
@@ -64,7 +64,7 @@ ReportOptionsDialog::ReportOptionsDialog(QWidget *parent)
 	connect(this, &ReportOptionsDialog::persistentSettingsIdChanged, [this]() {
 		loadPersistentSettings();
 	});
-    connect(ui->btReset, &QPushButton::clicked, this, &ReportOptionsDialog::resetPersistentSettings);
+	connect(ui->btReset, &QPushButton::clicked, this, &ReportOptionsDialog::resetPersistentSettings);
 
 	connect(this, &ReportOptionsDialog::startListOptionsVisibleChanged, ui->grpStartOptions, &QGroupBox::setVisible);
 	connect(this, &ReportOptionsDialog::classFilterVisibleChanged, ui->grpClassFilter, &QGroupBox::setVisible);

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.h
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.h
@@ -62,7 +62,6 @@ public:
 		QF_VARIANTMAP_FIELD2(int, c, setC, olumnCount, 2)
 		QF_VARIANTMAP_FIELD2(int, h, setH, orizontalMargin, 10)
 		QF_VARIANTMAP_FIELD2(int, v, setV, erticalMargin, 5)
-		QF_VARIANTMAP_FIELD2(bool, is, set, ShirinkPageWidthToColumnCount, false)
 		QF_VARIANTMAP_FIELD(QString, c, setC, lassFilter)
 		QF_VARIANTMAP_FIELD2(int, c, setC, lassFilterType, 0)
 		QF_VARIANTMAP_FIELD(bool, is, set, UseClassFilter)

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.h
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.h
@@ -32,6 +32,7 @@ class QUICKEVENTGUI_DECL_EXPORT ReportOptionsDialog : public QDialog, public qf:
 	Q_PROPERTY(bool resultOptionsVisible READ isResultOptionsVisible WRITE setResultOptionsVisible NOTIFY resultOptionsVisibleChanged)
 	Q_PROPERTY(bool startTimeFormatVisible READ isStartTimeFormatVisible WRITE setStartTimeFormatVisible NOTIFY startTimeFormatVisibleChanged)
 	Q_PROPERTY(bool startlistOrderFirstByVisible READ isStartlistOrderFirstByVisible WRITE setStartlistOrderFirstByVisible NOTIFY startlistOrderFirstByVisibleChanged)
+	Q_PROPERTY(bool classStartSelectionVisible READ isClassStartSelectionVisible WRITE setClassStartSelectionVisible NOTIFY classStartSelectionVisibleChanged)
 
 	QF_PROPERTY_BOOL_IMPL2(c, C, lassFilterVisible, true)
 	QF_PROPERTY_BOOL_IMPL2(s, S, tartListOptionsVisible, false)
@@ -44,6 +45,7 @@ class QUICKEVENTGUI_DECL_EXPORT ReportOptionsDialog : public QDialog, public qf:
 	QF_PROPERTY_BOOL_IMPL2(r, R, esultOptionsVisible, false)
 	QF_PROPERTY_BOOL_IMPL2(s, S, tartTimeFormatVisible, false)
 	QF_PROPERTY_BOOL_IMPL2(s, S, tartlistOrderFirstByVisible, false)
+	QF_PROPERTY_BOOL_IMPL2(c, C, lassStartSelectionVisible, false)
 private:
 	using Super = QDialog;
 public:
@@ -74,6 +76,8 @@ public:
 		QF_VARIANTMAP_FIELD2(bool, isR, setR, esultExcludeDisq, false)
 		QF_VARIANTMAP_FIELD2(int, s, setS, tartTimeFormat, 0)
 		QF_VARIANTMAP_FIELD2(int, s, setS, tartlistOrderFirstBy, 0)
+		QF_VARIANTMAP_FIELD(bool, is, set, UseClassStartSelectionFilter)
+		QF_VARIANTMAP_FIELD2(int, c, setC, lassStartNumber, 0)
 		public:
 			Options(const QVariantMap &o = QVariantMap()) : QVariantMap(o) {}
 	};
@@ -119,6 +123,7 @@ public:
 	Q_INVOKABLE int resultNumPlaces() const;
 	Q_INVOKABLE QString sqlWhereExpression() const;
 	static QString sqlWhereExpression(const Options &opts);
+	static QString getClassesForStartNumber(const int number);
 protected:
 	//void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
 private:

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.h
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.h
@@ -99,6 +99,7 @@ public:
 	void loadPersistentSettings(const Options &default_options);
 	Q_SLOT void loadPersistentSettings();
 	Q_SLOT void savePersistentSettings();
+    Q_SLOT void resetPersistentSettings();
 
 	void setClassNamesFilter(const QStringList &class_names);
 

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.h
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.h
@@ -121,9 +121,9 @@ public:
 	Q_INVOKABLE bool isBreakAfterEachClass() const {return breakType() != BreakType::None;}
 	Q_INVOKABLE bool isColumnBreak() const {return breakType() == BreakType::Column;}
 	Q_INVOKABLE int resultNumPlaces() const;
-	Q_INVOKABLE QString sqlWhereExpression() const;
-	static QString sqlWhereExpression(const Options &opts);
-	static QString getClassesForStartNumber(const int number);
+	Q_INVOKABLE QString sqlWhereExpression(const int stage_id = 1) const;
+	static QString sqlWhereExpression(const Options &opts, const int stage_id);
+	static QString getClassesForStartNumber(const int number, const int stage_id);
 protected:
 	//void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
 private:

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.ui
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.ui
@@ -91,13 +91,10 @@
       <property name="bottomMargin">
        <number>5</number>
       </property>
-      <item row="0" column="1">
-       <widget class="QRadioButton" name="btRegExp">
-        <property name="toolTip">
-         <string>Posix regular expression</string>
-        </property>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="chkClassFilterDoesntMatch">
         <property name="text">
-         <string>RegExp</string>
+         <string>Doesn't match</string>
         </property>
        </widget>
       </item>
@@ -114,10 +111,13 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="chkClassFilterDoesntMatch">
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="btRegExp">
+        <property name="toolTip">
+         <string>Posix regular expression</string>
+        </property>
         <property name="text">
-         <string>Doesn't match</string>
+         <string>RegExp</string>
         </property>
        </widget>
       </item>
@@ -133,6 +133,28 @@
       </item>
       <item row="1" column="0" colspan="3">
        <widget class="QLineEdit" name="edFilter"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="grpClassStartSelection">
+     <property name="title">
+      <string>Class filter - start number selection</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_11">
+        <property name="text">
+         <string>Use only class from selected start</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="cbxStartNumber"/>
       </item>
      </layout>
     </widget>
@@ -537,6 +559,8 @@
   <tabstop>btClassNames</tabstop>
   <tabstop>edFilter</tabstop>
   <tabstop>chkClassFilterDoesntMatch</tabstop>
+  <tabstop>grpClassStartSelection</tabstop>
+  <tabstop>cbxStartNumber</tabstop>
   <tabstop>edNumPlaces</tabstop>
   <tabstop>chkExcludeDisq</tabstop>
   <tabstop>edStartersOptionsLineSpacing</tabstop>
@@ -548,10 +572,10 @@
   <tabstop>btStartOrder2</tabstop>
   <tabstop>btStartOrder3</tabstop>
   <tabstop>edPageWidth</tabstop>
-  <tabstop>edPageHeight</tabstop>
   <tabstop>edHorizontalMargin</tabstop>
-  <tabstop>edVerticalMargin</tabstop>
   <tabstop>edColumnCount</tabstop>
+  <tabstop>edPageHeight</tabstop>
+  <tabstop>edVerticalMargin</tabstop>
   <tabstop>cbxBreakAfterClassType</tabstop>
   <tabstop>btSaveAsDefault</tabstop>
   <tabstop>btReset</tabstop>

--- a/libquickevent/libquickeventgui/src/reportoptionsdialog.ui
+++ b/libquickevent/libquickeventgui/src/reportoptionsdialog.ui
@@ -508,6 +508,13 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="btReset">
+       <property name="text">
+        <string>Reset</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -523,6 +530,7 @@
  </widget>
  <tabstops>
   <tabstop>edStagesCount</tabstop>
+  <tabstop>edLegsCount</tabstop>
   <tabstop>grpClassFilter</tabstop>
   <tabstop>btWildCard</tabstop>
   <tabstop>btRegExp</tabstop>
@@ -530,16 +538,23 @@
   <tabstop>edFilter</tabstop>
   <tabstop>chkClassFilterDoesntMatch</tabstop>
   <tabstop>edNumPlaces</tabstop>
+  <tabstop>chkExcludeDisq</tabstop>
   <tabstop>edStartersOptionsLineSpacing</tabstop>
   <tabstop>chkStartOpts_PrintVacants</tabstop>
   <tabstop>chkStartOpts_PrintStartNumbers</tabstop>
+  <tabstop>btStartTimes1</tabstop>
+  <tabstop>btStartTimes2</tabstop>
+  <tabstop>btStartOrder1</tabstop>
+  <tabstop>btStartOrder2</tabstop>
+  <tabstop>btStartOrder3</tabstop>
   <tabstop>edPageWidth</tabstop>
-  <tabstop>edHorizontalMargin</tabstop>
-  <tabstop>edColumnCount</tabstop>
   <tabstop>edPageHeight</tabstop>
+  <tabstop>edHorizontalMargin</tabstop>
   <tabstop>edVerticalMargin</tabstop>
+  <tabstop>edColumnCount</tabstop>
   <tabstop>cbxBreakAfterClassType</tabstop>
   <tabstop>btSaveAsDefault</tabstop>
+  <tabstop>btReset</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/quickevent/app/quickevent/plugins/Relays/qml/reports/results.qml
+++ b/quickevent/app/quickevent/plugins/Relays/qml/reports/results.qml
@@ -64,8 +64,8 @@ Report {
 	}
 	textStyle: myStyle.textStyleDefault
 
-	width: root.options.isShirinkPageWidthToColumnCount? 210/2*root.options.columnCount: 210
-	height: 297
+	width: root.options.pageWidth? root.options.pageWidth: 210
+	height: root.options.pageHeight? root.options.pageHeight: 297
 	hinset: root.options.horizontalMargin? root.options.horizontalMargin: 10
 	vinset: root.options.verticalMargin? root.options.verticalMargin: 5
 	Frame {

--- a/quickevent/app/quickevent/plugins/Relays/qml/reports/results_condensed.qml
+++ b/quickevent/app/quickevent/plugins/Relays/qml/reports/results_condensed.qml
@@ -64,8 +64,8 @@ Report {
 	}
 	textStyle: myStyle.textStyleDefault
 
-	width: root.options.isShirinkPageWidthToColumnCount? 210/2*root.options.columnCount: 210
-	height: 297
+	width: root.options.pageWidth? root.options.pageWidth: 210
+	height: root.options.pageHeight? root.options.pageHeight: 297
 	hinset: root.options.horizontalMargin? root.options.horizontalMargin: 10
 	vinset: root.options.verticalMargin? root.options.verticalMargin: 5
 	Frame {

--- a/quickevent/app/quickevent/plugins/Relays/qml/reports/startList_classes.qml
+++ b/quickevent/app/quickevent/plugins/Relays/qml/reports/startList_classes.qml
@@ -32,8 +32,8 @@ Report {
 	}
 	textStyle: myStyle.textStyleDefault
 
-	width: root.options.isShirinkPageWidthToColumnCount? 210/2*root.options.columnCount: 210
-	height: 297
+	width: root.options.pageWidth? root.options.pageWidth: 210
+	height: root.options.pageHeight? root.options.pageHeight: 297
 	hinset: root.options.horizontalMargin? root.options.horizontalMargin: 10
 	vinset: root.options.verticalMargin? root.options.verticalMargin: 5
 	Frame {

--- a/quickevent/app/quickevent/plugins/Relays/qml/reports/startList_clubs.qml
+++ b/quickevent/app/quickevent/plugins/Relays/qml/reports/startList_clubs.qml
@@ -32,8 +32,8 @@ Report {
 	}
 	textStyle: myStyle.textStyleDefault
 
-	width: root.options.isShirinkPageWidthToColumnCount? 210/2*root.options.columnCount: 210
-	height: 297
+	width: root.options.pageWidth? root.options.pageWidth: 210
+	height: root.options.pageHeight? root.options.pageHeight: 297
 	hinset: root.options.horizontalMargin? root.options.horizontalMargin: 10
 	vinset: root.options.verticalMargin? root.options.verticalMargin: 5
 	Frame {

--- a/quickevent/app/quickevent/plugins/Runs/qml/reports/competitorsWithCardRent.qml
+++ b/quickevent/app/quickevent/plugins/Runs/qml/reports/competitorsWithCardRent.qml
@@ -8,6 +8,7 @@ Report {
 	id: root
 	objectName: "root"
 
+	property var options
 	property string reportTitle: qsTr("Competitors with rented cards in stage %1").arg(stageId);
 	property var stageId
 
@@ -19,10 +20,10 @@ Report {
 	}
 	textStyle: myStyle.textStyleDefault
 
-	width: 210
-	height: 297
-	hinset: 5
-	vinset: 5
+	width: root.options.pageWidth? root.options.pageWidth: 210
+	height: root.options.pageHeight? root.options.pageHeight: 297
+	hinset: root.options.horizontalMargin? root.options.horizontalMargin: 10
+	vinset: root.options.verticalMargin? root.options.verticalMargin: 5
 	Frame {
 		width: "%"
 		height: "%"

--- a/quickevent/app/quickevent/plugins/Runs/qml/reports/results_nstages.qml
+++ b/quickevent/app/quickevent/plugins/Runs/qml/reports/results_nstages.qml
@@ -82,10 +82,10 @@ Report {
 	}
 	textStyle: myStyle.textStyleDefault
 
-	width: 210
-	height: 297
-	hinset: 5
-	vinset: 5
+	width: root.options.pageWidth? root.options.pageWidth: 210
+	height: root.options.pageHeight? root.options.pageHeight: 297
+	hinset: root.options.horizontalMargin? root.options.horizontalMargin: 10
+	vinset: root.options.verticalMargin? root.options.verticalMargin: 5
 	Frame {
 		width: "%"
 		height: "%"

--- a/quickevent/app/quickevent/plugins/Runs/qml/reports/results_nstagesSpeaker.qml
+++ b/quickevent/app/quickevent/plugins/Runs/qml/reports/results_nstagesSpeaker.qml
@@ -7,6 +7,7 @@ import "qrc:/quickevent/core/js/ogtime.js" as OGTime
 Report {
 	id: root
 
+	property var options
 	property int stagesCount: 1
 	//property bool excludeDisqualified: true
 
@@ -79,10 +80,10 @@ Report {
 	}
 	textStyle: myStyle.textStyleDefault
 
-	width: 210
-	height: 297
-	hinset: 5
-	vinset: 5
+	width: root.options.pageWidth? root.options.pageWidth: 210
+	height: root.options.pageHeight? root.options.pageHeight: 297
+	hinset: root.options.horizontalMargin? root.options.horizontalMargin: 10
+	vinset: root.options.verticalMargin? root.options.verticalMargin: 5
 	Frame {
 		width: "%"
 		height: "%"

--- a/quickevent/app/quickevent/plugins/Runs/qml/reports/startList_starters.qml
+++ b/quickevent/app/quickevent/plugins/Runs/qml/reports/startList_starters.qml
@@ -31,8 +31,8 @@ Report {
 	}
 	textStyle: myStyle.textStyleDefault
 
-	width: root.options.isShirinkPageWidthToColumnCount? 210 / 2 * root.options.columnCount: 210
-	height: 297
+	width: root.options.pageWidth? root.options.pageWidth: 210
+	height: root.options.pageHeight? root.options.pageHeight: 297
 	hinset: root.options.horizontalMargin? root.options.horizontalMargin: 10
 	vinset: root.options.verticalMargin? root.options.verticalMargin: 5
 	Frame {

--- a/quickevent/app/quickevent/plugins/Runs/src/eventstatisticswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/eventstatisticswidget.cpp
@@ -560,7 +560,7 @@ void EventStatisticsWidget::printResultsForRows(const QList<int> &rows)
 		opts.setClassFilterType((int)quickevent::gui::ReportOptionsDialog::FilterType::ClassName);
 		opts.setClassFilter(class_names.join(','));
 	}
-	QVariant td = getPlugin<RunsPlugin>()->currentStageResultsTableData(quickevent::gui::ReportOptionsDialog::sqlWhereExpression(opts));
+	QVariant td = getPlugin<RunsPlugin>()->currentStageResultsTableData(quickevent::gui::ReportOptionsDialog::sqlWhereExpression(opts, getPlugin<EventPlugin>()->currentStageId()));
 	QVariantMap props;
 	props["isBreakAfterEachClass"] = (opts.breakType() != (int)quickevent::gui::ReportOptionsDialog::BreakType::None);
 	props["isColumnBreak"] = (opts.breakType() == (int)quickevent::gui::ReportOptionsDialog::BreakType::Column);

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -1433,6 +1433,7 @@ void RunsPlugin::report_startListClasses()
 	dlg.setStartListOptionsVisible(true);
 	dlg.setPageLayoutVisible(true);
 	dlg.setStartTimeFormatVisible(true);
+	dlg.setClassStartSelectionVisible(true);
 	if(dlg.exec()) {
 		auto tt = startListClassesTable(dlg.sqlWhereExpression(), dlg.isStartListPrintVacants(), dlg.startTimeFormat());
 		auto opts = dlg.optionsMap();
@@ -1486,6 +1487,7 @@ void RunsPlugin::report_startListStarters()
 	dlg.setStartListOptionsVisible(true);
 	dlg.setStartListPrintVacantsVisible(false);
 	dlg.setStartersOptionsVisible(true);
+	dlg.setClassStartSelectionVisible(true);
 	if(dlg.exec()) {
 		auto tt = startListStartersTable(dlg.sqlWhereExpression());
 		auto opts = dlg.optionsMap();

--- a/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runsplugin.cpp
@@ -1435,7 +1435,7 @@ void RunsPlugin::report_startListClasses()
 	dlg.setStartTimeFormatVisible(true);
 	dlg.setClassStartSelectionVisible(true);
 	if(dlg.exec()) {
-		auto tt = startListClassesTable(dlg.sqlWhereExpression(), dlg.isStartListPrintVacants(), dlg.startTimeFormat());
+		auto tt = startListClassesTable(dlg.sqlWhereExpression(getPlugin<EventPlugin>()->currentStageId()), dlg.isStartListPrintVacants(), dlg.startTimeFormat());
 		auto opts = dlg.optionsMap();
 		QVariantMap props;
 		props["options"] = opts;
@@ -1489,7 +1489,7 @@ void RunsPlugin::report_startListStarters()
 	dlg.setStartersOptionsVisible(true);
 	dlg.setClassStartSelectionVisible(true);
 	if(dlg.exec()) {
-		auto tt = startListStartersTable(dlg.sqlWhereExpression());
+		auto tt = startListStartersTable(dlg.sqlWhereExpression(getPlugin<EventPlugin>()->currentStageId()));
 		auto opts = dlg.optionsMap();
 		QVariantMap props;
 		props["options"] = opts;


### PR DESCRIPTION
- Fix page layouts for use with receipt printer
- ReportOptionsDialog  
  - add Reset button
  - add select start number for print startlist by classes and for starters

Affects #805, #253, #213, #373