### PR TITLE
qfcore: logging: Define functions in a cpp file

### DIFF
--- a/libqf/libqfcore/CMakeLists.txt
+++ b/libqf/libqfcore/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(libqfcore SHARED
     src/core/collator.cpp
     src/core/exception.cpp
+    src/core/log.cpp
     src/core/logentrymap.cpp
     src/core/stacktrace.cpp
     src/core/string.cpp

--- a/libqf/libqfcore/src/core/core.pri
+++ b/libqf/libqfcore/src/core/core.pri
@@ -13,6 +13,7 @@ SOURCES += \
 	$$PWD/exception.cpp \
     $$PWD/logentrymap.cpp \
 	$$PWD/stacktrace.cpp \
+	$$PWD/log.cpp \
 	$$PWD/string.cpp \
     $$PWD/utils.cpp \
     $$PWD/collator.cpp \

--- a/libqf/libqfcore/src/core/log.cpp
+++ b/libqf/libqfcore/src/core/log.cpp
@@ -1,0 +1,45 @@
+#include "log.h"
+NecroLog operator<<(NecroLog log, const QString &s) { return log.operator<<(s.toStdString()); }
+NecroLog operator<<(NecroLog log, const QDateTime &dt) { return log.operator<<(dt.toString(Qt::ISODateWithMs).toStdString()); }
+NecroLog operator<<(NecroLog log, const QDate &dt) { return log.operator<<(dt.toString(Qt::ISODateWithMs).toStdString()); }
+NecroLog operator<<(NecroLog log, const QTime &dt) { return log.operator<<(dt.toString(Qt::ISODateWithMs).toStdString()); }
+NecroLog operator<<(NecroLog log, const QUrl &url) { return log.operator<<(url.toString().toStdString()); }
+NecroLog operator<<(NecroLog log, const QStringList &sl) {
+	QString s = '[' + sl.join(',') + ']';
+	return log.operator<<(s.toStdString());
+}
+NecroLog operator<<(NecroLog log, const QByteArray &ba) {
+	QString s = ba.toHex();
+	return log.operator<<(s.toStdString());
+}
+NecroLog operator<<(NecroLog log, const QVariant &v) {
+	QString s = v.toString();
+	return log.operator<<(s.toStdString());
+}
+NecroLog operator<<(NecroLog log, const qf::core::String &s) { return log.operator<<(s.toStdString()); }
+NecroLog operator<<(NecroLog log, const QPoint &p) {
+	QString s = "QPoint(%1, %2)";
+	return log.operator<<(s.arg(p.x()).arg(p.y()).toStdString());
+}
+NecroLog operator<<(NecroLog log, const QPointF &p) {
+	QString s = "QPoint(%1, %2)";
+	return log.operator<<(s.arg(p.x()).arg(p.y()).toStdString());
+}
+NecroLog operator<<(NecroLog log, const QSize &sz) {
+	QString s = "QSize(%1, %2)";
+	return log.operator<<(s.arg(sz.width()).arg(sz.height()).toStdString());
+}
+NecroLog operator<<(NecroLog log, const QSizeF &sz) {
+	QString s = "QSize(%1, %2)";
+	return log.operator<<(s.arg(sz.width()).arg(sz.height()).toStdString());
+}
+NecroLog operator<<(NecroLog log, const QRect &r) {
+	QString s = "QRect(%1, %2, %3 x %4)";
+	return log.operator<<(s.arg(r.x()).arg(r.y())
+	                      .arg(r.width()).arg(r.height()).toStdString());
+}
+NecroLog operator<<(NecroLog log, const QRectF &r) {
+	QString s = "QRect(%1, %2, %3 x %4)";
+	return log.operator<<(s.arg(r.x()).arg(r.y())
+	                      .arg(r.width()).arg(r.height()).toStdString());
+}

--- a/libqf/libqfcore/src/core/log.h
+++ b/libqf/libqfcore/src/core/log.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "string.h"
+#include "coreglobal.h"
 #include <QVariant>
 #include <QMetaType>
 #include <QString>
@@ -42,47 +43,18 @@
 
 #define qfFatal(msg) {qfError() << msg; abort();}
 
-inline NecroLog operator<<(NecroLog log, const QString &s) { return log.operator<<(s.toStdString()); }
-inline NecroLog operator<<(NecroLog log, const QDateTime &dt) { return log.operator<<(dt.toString(Qt::ISODateWithMs).toStdString()); }
-inline NecroLog operator<<(NecroLog log, const QDate &dt) { return log.operator<<(dt.toString(Qt::ISODateWithMs).toStdString()); }
-inline NecroLog operator<<(NecroLog log, const QTime &dt) { return log.operator<<(dt.toString(Qt::ISODateWithMs).toStdString()); }
-inline NecroLog operator<<(NecroLog log, const QUrl &url) { return log.operator<<(url.toString().toStdString()); }
-inline NecroLog operator<<(NecroLog log, const QStringList &sl) {
-	QString s = '[' + sl.join(',') + ']';
-	return log.operator<<(s.toStdString());
-}
-inline NecroLog operator<<(NecroLog log, const QByteArray &ba) {
-	QString s = ba.toHex();
-	return log.operator<<(s.toStdString());
-}
-inline NecroLog operator<<(NecroLog log, const QVariant &v) {
-	QString s = v.toString();
-	return log.operator<<(s.toStdString());
-}
-inline NecroLog operator<<(NecroLog log, const qf::core::String &s) { return log.operator<<(s.toStdString()); }
-inline NecroLog operator<<(NecroLog log, const QPoint &p) {
-	QString s = "QPoint(%1, %2)";
-	return log.operator<<(s.arg(p.x()).arg(p.y()).toStdString());
-}
-inline NecroLog operator<<(NecroLog log, const QPointF &p) {
-	QString s = "QPoint(%1, %2)";
-	return log.operator<<(s.arg(p.x()).arg(p.y()).toStdString());
-}
-inline NecroLog operator<<(NecroLog log, const QSize &sz) {
-	QString s = "QSize(%1, %2)";
-	return log.operator<<(s.arg(sz.width()).arg(sz.height()).toStdString());
-}
-inline NecroLog operator<<(NecroLog log, const QSizeF &sz) {
-	QString s = "QSize(%1, %2)";
-	return log.operator<<(s.arg(sz.width()).arg(sz.height()).toStdString());
-}
-inline NecroLog operator<<(NecroLog log, const QRect &r) {
-	QString s = "QRect(%1, %2, %3 x %4)";
-	return log.operator<<(s.arg(r.x()).arg(r.y())
-	                      .arg(r.width()).arg(r.height()).toStdString());
-}
-inline NecroLog operator<<(NecroLog log, const QRectF &r) {
-	QString s = "QRect(%1, %2, %3 x %4)";
-	return log.operator<<(s.arg(r.x()).arg(r.y())
-	                      .arg(r.width()).arg(r.height()).toStdString());
-}
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QString &s);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QDateTime &dt);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QDate &dt);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QTime &dt);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QUrl &url);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QStringList &sl);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QByteArray &ba);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QVariant &v);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const qf::core::String &s);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QPoint &p);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QPointF &p);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QSize &sz);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QSizeF &sz);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QRect &r);
+NecroLog QFCORE_DECL_EXPORT operator<<(NecroLog log, const QRectF &r);


### PR DESCRIPTION
Having these defined in the header and somewhere else NOT in the header (libshv) causes linking issues in Windows.