### PR TITLE
Fix issues 953 & 954 for QE3

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup CMake
         uses: ./.github/actions/cmake
         with:
-          qt_version: 6.6.2
+          qt_version: 6.6.3
           qt_arch: win64_mingw
           use_qt6: ON
           modules: qtserialport qtmultimedia

--- a/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
+++ b/quickevent/app/quickevent/plugins/Event/src/services/emmaclient.cpp
@@ -37,6 +37,7 @@ namespace Event {
 namespace services {
 
 constexpr int HR_12_MSEC = 12 * 60 * 60 * 1000;
+constexpr int INVALID_SI_TIME = 61166; // 0xEEEE
 
 EmmaClient::EmmaClient(QObject *parent)
 	: Super(EmmaClient::serviceName(), parent)
@@ -445,9 +446,10 @@ void EmmaClient::exportStartListRacomTxt()
 		last_id = id;
 		int si = q2.value("runs.siId").toInt();
 		int start_time = q2.value("runs.startTimeMs").toInt();
-		bool start_time_card_null = q2.value("runs.startTimeMs").isNull();
+		bool start_time_null = q2.value("runs.startTimeMs").isNull();
 		int start_time_card = q2.value("cards.startTime").toInt();
-		if (start_time_card == 61166 || start_time_card_null)
+		bool start_time_card_null = q2.value("cards.startTime").isNull();
+		if ((start_time_card == INVALID_SI_TIME || start_time_card_null) && start_time_null)
 			start_time_card = 0;
 		QString name = q2.value("competitors.lastName").toString() + " " + q2.value("competitors.firstName").toString();
 		QString class_name = q2.value("classes.name").toString();
@@ -573,9 +575,10 @@ void EmmaClient::exportStartListRacomCsv()
 		int si = q2.value("runs.siId").toInt();
 		int start_time = q2.value("runs.startTimeMs").toInt();
 		int bib = q2.value("competitors.startNumber").toInt();
-		bool start_time_card_null = q2.value("runs.startTimeMs").isNull();
+		bool start_time_null = q2.value("runs.startTimeMs").isNull();
 		int start_time_card = q2.value("cards.startTime").toInt();
-		if (start_time_card == 61166 || start_time_card_null)
+		bool start_time_card_null = q2.value("cards.startTime").isNull();
+		if ((start_time_card == INVALID_SI_TIME || start_time_card_null) && start_time_null)
 			start_time_card = 0;
 		QString name = q2.value("competitors.lastName").toString() + " " + q2.value("competitors.firstName").toString();
 		QString class_name = q2.value("classes.name").toString();

--- a/quickevent/app/quickevent/plugins/Runs/src/runswidget.cpp
+++ b/quickevent/app/quickevent/plugins/Runs/src/runswidget.cpp
@@ -220,9 +220,21 @@ void RunsWidget::settleDownInPartWidget(::PartWidget *part_widget)
 		auto *a = new qfw::Action(tr("&Competitors with rented cards"));
 		connect(a, &qfw::Action::triggered, [this]() {
 			qff::MainWindow *fwk = qff::MainWindow::frameWork();
+			quickevent::gui::ReportOptionsDialog dlg(fwk);
+			dlg.setPersistentSettingsId("competitorsWithRentedCards");
+			dlg.loadPersistentSettings();
+			dlg.setClassFilterVisible(false);
+			dlg.setStartListOptionsVisible(false);
+			dlg.setStartListPrintVacantsVisible(false);
+			dlg.setPageLayoutVisible(true);
+			dlg.setStartTimeFormatVisible(false);
+			dlg.setStartlistOrderFirstByVisible(false);
+			if(!dlg.exec())
+				return;
+			auto opts = dlg.optionsMap();
 			QVariantMap props;
 			props["stageId"] = selectedStageId();
-			props["options"] = QVariantMap();
+			props["options"] = opts;
 			qf::qmlwidgets::reports::ReportViewWidget::showReport(fwk
 										, getPlugin<RunsPlugin>()->findReportFile("competitorsWithCardRent.qml")
 										, QVariant()


### PR DESCRIPTION
Fix issue #953, better computation of start time for Emma Client (racom type). Fix when runs.startTimeMs is null.

Fix issue #954, add missing ReportOptionsDialog PageLayout call

And try to fix windows installer action (Qt 6.6.3)