### PR TITLE
Fix XML export for relays.

### DIFF
--- a/libquickevent/libquickeventcore/src/runstatus.h
+++ b/libquickevent/libquickeventcore/src/runstatus.h
@@ -25,6 +25,14 @@ public:
 	QString toHtmlExportString() const;
 	QString toString() const;
 
+	void setDisqualified(bool value) { m_disqualified = value; }
+	void setDisqualifiedByOrganizer(bool value)  { m_disqualifiedByOrganizer = value; }
+	void setNotCompeting(bool value) { m_notCompeting = value; }
+	void setMissingPunch(bool value) { m_missingPunch = value; }
+	void setDidNotStart(bool value) { m_didNotStart = value; }
+	void setDidNotFinish(bool value) { m_didNotFinish = value; }
+	void setOverTime(bool value) { m_overTime = value; }
+
 	bool idDisqualified() const { return m_disqualified; }
 	bool isDisqualifiedByOrganizer() const { return m_disqualifiedByOrganizer; }
 	bool isNotCompeting() const { return m_notCompeting; }

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define APP_VERSION "2.6.29"
+#define APP_VERSION "2.6.30"
 


### PR DESCRIPTION
Fix for incomplete relays.
TeamMemberResult - One element per relay leg must be included, even if the team has not assigned any team member to the leg.

[IOF XML datastandard v3 - Ln2580](https://github.com/international-orienteering-federation/datastandard-v3/blob/24eb108e4c6b5e2904e5f8f0e49142e45e2c5230/IOF.xsd#L2580)