### PR TITLE
Fix XML export for relays qe3.

### DIFF
--- a/libquickevent/libquickeventcore/src/runstatus.h
+++ b/libquickevent/libquickeventcore/src/runstatus.h
@@ -24,6 +24,13 @@ public:
 	QString toHtmlExportString() const;
 	QString toString() const;
 
+	void setDisqualifiedByOrganizer(bool value)  { m_disqualifiedByOrganizer = value; }
+	void setNotCompeting(bool value) { m_notCompeting = value; }
+	void setMissingPunch(bool value) { m_missingPunch = value; }
+	void setDidNotStart(bool value) { m_didNotStart = value; }
+	void setDidNotFinish(bool value) { m_didNotFinish = value; }
+	void setOverTime(bool value) { m_overTime = value; }
+
 	bool isDisqualifiedByOrganizer() const { return m_disqualifiedByOrganizer; }
 	bool isNotCompeting() const { return m_notCompeting; }
 	bool isMissingPunch() const { return m_missingPunch; }

--- a/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
+++ b/quickevent/app/quickevent/plugins/Relays/src/relaysplugin.cpp
@@ -656,7 +656,29 @@ QString RelaysPlugin::resultsIofXml30()
 				const qf::core::utils::TreeTableRow tt_leg_row = tt_legs.row(k);
 				auto time = quickevent::core::og::TimeMs::fromVariant(tt_leg_row.value("time"));
 				// omit from export if leg does not exist (rundId == 0) or runner with OK status did not finish yet
-				if (tt_leg_row.value("runId").toInt() == 0 || (time.isValid() && time.msec() == 0))
+				if (tt_leg_row.value("runId").toInt() == 0) {
+					// empty TeamMemberResult if leg does not exists - defined in IOF XML v3
+					// https://github.com/international-orienteering-federation/datastandard-v3/blob/24eb108e4c6b5e2904e5f8f0e49142e45e2c5230/IOF.xsd#L2580
+					qfDebug() << "Empty LEG for : Leg " << k+1 << ", Bib " << QString::number(relay_number) + '.' + QString::number(k+1);
+					QVariantList member_result{"TeamMemberResult"};
+					QVariantList person_result{"Result"};
+					append_list(person_result, QVariantList{"Leg", k+1 } );
+					append_list(person_result, QVariantList{"BibNumber", QString::number(relay_number) + '.' + QString::number(k+1)});
+					quickevent::core::RunStatus dns;
+					dns.setDidNotStart(true);
+					append_list(person_result, QVariantList{"Status", dns.toXmlExportString()});
+					QVariantList overall_result{"OverallResult"};
+					{
+						quickevent::core::RunStatus dnf;
+						dnf.setDidNotFinish(true);
+						append_list(overall_result, QVariantList{"Status", dnf.toXmlExportString()});
+					}
+					append_list(person_result, overall_result);
+					append_list(member_result, person_result);
+					append_list(team_result, member_result);
+					continue;
+				}
+				else if (time.isValid() && time.msec() == 0)
 					continue;
 				QVariantList member_result{"TeamMemberResult"};
 				QVariantList person{"Person"};

--- a/quickevent/app/quickevent/src/appversion.h
+++ b/quickevent/app/quickevent/src/appversion.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#define APP_VERSION "3.2.1"
+#define APP_VERSION "3.2.2"
 


### PR DESCRIPTION
Fix for incomplete relays.
TeamMemberResult - One element per relay leg must be included, even if the team has not assigned any team member to the leg.

[IOF XML datastandard v3 - Ln2580](https://github.com/international-orienteering-federation/datastandard-v3/blob/24eb108e4c6b5e2904e5f8f0e49142e45e2c5230/IOF.xsd#L2580)

QE3 branch