### PR TITLE
Update build - replaced deprecated Node.js version

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,12 +13,12 @@ jobs:
   build_linux:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         cache: 'true'
         version: ${{ env.QT_VERSION }}
@@ -42,13 +42,13 @@ jobs:
         ./quickevent/make-dist.sh --src-dir . --qt-dir ${Qt5_DIR} --work-dir ./build --appimage-tool /opt/appimagetool-x86_64.AppImage 
 
     - name: Save AppImage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: quickevent-${{ env.VERSION }}-linux64.Appimage
         path: build/artifacts/quickevent-*-linux64.AppImage
 
     - name: Save gzip
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: quickevent-${{ env.VERSION }}-linux64.tgz
         path: build/artifacts/quickevent-*-linux64.tgz
@@ -61,13 +61,13 @@ jobs:
         shell: bash
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
     - name: Cache Libs
       id: cache-libs
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           C:/openssl/bin/libssl-1_1-x64.dll
@@ -87,7 +87,7 @@ jobs:
       shell: cmd
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         cache: 'true'
         version: ${{ env.QT_VERSION }}
@@ -107,11 +107,11 @@ jobs:
     - name: Create installer
       run: |
         choco install innosetup --no-progress
-        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" "/DVERSION=%VERSION%" "/DQT_DIR=%Qt5_Dir%" "/DPSQL_DIR=C:/Program Files/PostgreSQL/14" "/DSSL_DIR=C:\openssl\bin" quickevent/quickevent.iss
+        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" "/DVERSION=%VERSION%" "/DQT_DIR=%QT_ROOT_DIR%" "/DPSQL_DIR=C:/Program Files/PostgreSQL/14" "/DSSL_DIR=C:\openssl\bin" quickevent/quickevent.iss
       shell: cmd
 
     - name: Save setup
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: quickevent-${{ env.VERSION }}-win64-setup.exe
         path: _inno\quickevent\quickevent-${{ env.VERSION }}-win64-setup.exe

--- a/quickevent/make-dist.sh
+++ b/quickevent/make-dist.sh
@@ -113,10 +113,11 @@ echo APP_NAME: $APP_NAME
 echo SRC_DIR: $SRC_DIR
 echo WORK_DIR: $WORK_DIR
 echo NO_CLEAN: $NO_CLEAN
+echo QT_ROOT_DIR: $QT_ROOT_DIR
 
 if [ -z $USE_SYSTEM_QT ]; then
-	QT_LIB_DIR=$QT_DIR/lib
-	QMAKE=$QT_DIR/bin/qmake
+	QT_LIB_DIR=$QT_ROOT_DIR/lib
+	QMAKE=$QT_ROOT_DIR/bin/qmake
 	DISTRO_NAME=$APP_NAME-$APP_VER-linux64
 else
 	QT_DIR=/usr/lib/i386-linux-gnu/qt5


### PR DESCRIPTION
In action there was 3 warnings :

* build_linux
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/upload-artifact@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

* build_linux
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/upload-artifact@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

* Deprecation notice: v1, v2, and v3 of the artifact actions
The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "quickevent-2.6.29-linux64.Appimage", "quickevent-2.6.29-linux64.tgz", "quickevent-2.6.29-win64-setup.exe".
Please update your workflow to use v4 of the artifact actions.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Updated build to actions v4 .