### PR TITLE
QE3 - Update build - replaced deprecated Node.js version.

### DIFF
--- a/.github/actions/appimage/action.yml
+++ b/.github/actions/appimage/action.yml
@@ -36,9 +36,9 @@ runs:
 
     - name: Remove not needed SQL plugins
       run: |
-        rm ${{ env.Qt6_DIR }}/plugins/sqldrivers/libqsqlmimer.so
-        rm ${{ env.Qt6_DIR }}/plugins/sqldrivers/libqsqlmysql.so
-        rm ${{ env.Qt6_DIR }}/plugins/sqldrivers/libqsqlodbc.so
+        rm ${{ env.QT_ROOT_DIR }}/plugins/sqldrivers/libqsqlmimer.so
+        rm ${{ env.QT_ROOT_DIR }}/plugins/sqldrivers/libqsqlmysql.so
+        rm ${{ env.QT_ROOT_DIR }}/plugins/sqldrivers/libqsqlodbc.so
       shell: bash
 
     - name: Create AppImage
@@ -54,7 +54,7 @@ runs:
       shell: bash
 
     - name: Upload AppImage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: quickevent-${{ env.VERSION }}-x86_64.Appimage
         path: QuickEvent-*-x86_64.AppImage

--- a/.github/actions/cmake/action.yml
+++ b/.github/actions/cmake/action.yml
@@ -23,7 +23,7 @@ runs:
     # Linux deps
     - name: Install/cache clazy, ninja, openldap, doctest libfuse, and Qt's dependencies
       if: runner.os != 'Windows'
-      uses: awalsh128/cache-apt-pkgs-action@v1.3.0
+      uses: awalsh128/cache-apt-pkgs-action@v1.4.1
       with:
         packages: ninja-build libgl1-mesa-dev libpulse-dev libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-util1 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev clazy libfuse-dev libgstreamer-gl1.0-0 libgstreamer-plugins-base1.0-0
         version: 1.0
@@ -37,7 +37,7 @@ runs:
 
     # Qt
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         cache: true
         version: ${{ inputs.qt_version }}

--- a/.github/actions/run-linter/action.yml
+++ b/.github/actions/run-linter/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Setup CMake
       uses: ./.github/actions/cmake
       with:
-        qt_version: 6.5.3
+        qt_version: 6.6.3
         use_qt6: ON
         modules: qtserialport qtmultimedia
         additional_cmake_args: -DCMAKE_GLOBAL_AUTOGEN_TARGET=ON -DCMAKE_AUTOGEN_ORIGIN_DEPENDS=OFF

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   ubuntu-qe3:
-    name: Qt 6.5 / Ubuntu 22.04
+    name: Qt 6.6 / Ubuntu 22.04
     runs-on: ubuntu-22.04
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   windows:
-    name: Qt 6.7 / Windows
+    name: Qt 6.8 / Windows
     runs-on: windows-2022
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -79,7 +79,7 @@ jobs:
         run: iscc "-DBUILD_DIR=${{ github.workspace }}/install" "-DVERSION=${{ env.VERSION }}" quickevent/quickevent.iss
 
       - name: Upload installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: quickevent-${{ env.VERSION }}-setup.exe
           path: ${{ github.workspace }}/install/_inno/quickevent/quickevent-*-setup.exe

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       CXX: clang++
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           
@@ -32,7 +32,7 @@ jobs:
       CXX: clang++
     steps:
       - name: Clone the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
 


### PR DESCRIPTION
Updated build to actions v4.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Fixed builds :
- AppImage
- Installer
- Lint